### PR TITLE
build: support latest dtc subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,13 +11,13 @@ project('culvert', 'c',
 	version: 'v0.4.0')
 
 libfdt_dep = dependency('libfdt',
-			default_options: [ 'warning_level=1', ],
+			default_options: [ 'warning_level=1', 'default_library=shared'],
 			fallback: [ 'dtc', 'libfdt_dep' ],
 			required: true)
 
 libfdt_native_dep = dependency('dtc',
 		     native: true,
-		     default_options: [ 'tools=enable' ],
+		     default_options: [ 'tools=enable', 'default_library=shared' ],
 		     fallback: [ 'dtc', 'libfdt_dep' ],
 		     required: true)
 


### PR DESCRIPTION
We need to set 'default_library=shared' when building dtc as a
subproject because it defaults to building both a `library` and a
`static_library` of the same name.  When a project is built as a
subproject, `library` defaults to static also unless
`default_library=shared` is passed.  This results in an error such as:

subprojects/dtc/libfdt/meson.build:27:0: ERROR: Tried to create target "fdt", but a target of that name already exists.

By setting `default_library=shared`, the `library` directive becomes a
shared library and does not conflict with the `static_library` directive
of the same name.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
