### PR TITLE
dtc: Pin to v1.6.1

### DIFF
--- a/subprojects/dtc.wrap
+++ b/subprojects/dtc.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://git.kernel.org/pub/scm/utils/dtc/dtc.git
-revision = HEAD
+revision = v1.6.1


### PR DESCRIPTION
For the most part this is a work-around to [1], but we should probably
track tags regardless, rather than relying on master.

[1] https://github.com/amboar/culvert/pull/21

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>