### PR TITLE
Fix -Wuninitialized warning spotted in clang

### DIFF
--- a/src/soc/wdt.c
+++ b/src/soc/wdt.c
@@ -89,7 +89,7 @@ int wdt_prevent_reset(struct soc *soc)
 
         if (!(wdt = wdt_get_by_name(soc, name))) {
             logd("Failed to acquire %s controller\n", name);
-            return rc;
+            return -ENODEV;
         }
 
         rc = wdt_stop(wdt);


### PR DESCRIPTION
This fixes:

    ../src/soc/wdt.c:92:20: warning: variable 'rc' is uninitialized when used
    here [-Wuninitialized]