### PR TITLE
devmem: Reorder headers

### DIFF
--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -1,18 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2018,2019 IBM Corp.
 
-#include "ahb.h"
-#include "ast.h"
-#include "bridge.h"
-#include "compiler.h"
-#include "devmem.h"
-#include "log.h"
-#include "mb.h"
-#include "mmio.h"
-#include "rev.h"
-
-#include "ccan/container_of/container_of.h"
-
 #include <assert.h>
 #include <endian.h>
 #include <errno.h>
@@ -23,6 +11,18 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include "ccan/container_of/container_of.h"
+
+#include "ahb.h"
+#include "ast.h"
+#include "bridge.h"
+#include "compiler.h"
+#include "devmem.h"
+#include "log.h"
+#include "mb.h"
+#include "mmio.h"
+#include "rev.h"
 
 #define AST_SOC_IO	0x1e600000
 #define AST_SOC_IO_LEN	0x00200000


### PR DESCRIPTION
Convention is to include system headers first, and local ones last. This resolves a build issue on centos7:

 cc -Isrc/culvert.p -Isrc -I../src -I../src/arch/x86_64 -Isrc/devicetree
 -flto -DNDEBUG -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra
 -std=gnu99 -O2 -g -MD -MQ src/culvert.p/bridge_devmem.c.o -MF
 src/culvert.p/bridge_devmem.c.o.d -o src/culvert.p/bridge_devmem.c.o -c
 ../src/bridge/devmem.c
 In file included from /usr/include/fcntl.h:77:0,
                  from ../src/bridge/devmem.c:19:
 /usr/include/bits/stat.h:106:31: error: expected identifier or '(' before '[' token
      __syscall_slong_t __unused[3];
                               ^