### PR TITLE
Let `write firmware` work on an erased firmware flash

### DIFF
--- a/src/devicetree/g5.dts
+++ b/src/devicetree/g5.dts
@@ -78,6 +78,10 @@
 				compatible = "aspeed,ast2500-scu", "syscon", "simple-mfd";
 				reg = <0x1e6e2000 0x1a8>;
 
+				clock {
+					compatible = "aspeed,ast2500-clock";
+				};
+
 				strapping {
 					compatible = "aspeed,ast2500-strapping";
 				};

--- a/src/soc/meson.build
+++ b/src/soc/meson.build
@@ -6,6 +6,7 @@ src += files(
 	'ilpcctl.c',
 	'otp.c',
 	'pciectl.c',
+	'scu.c',
 	'sdmc.c',
 	'sfc.c',
 	'sioctl.c',

--- a/src/soc/scu.c
+++ b/src/soc/scu.c
@@ -87,7 +87,9 @@ static void scu_driver_destroy(struct soc_device *dev)
 }
 
 static const struct soc_device_id scu_match[] = {
+	{ .compatible = "aspeed,ast2400-scu" },
 	{ .compatible = "aspeed,ast2500-scu" },
+	{ .compatible = "aspeed,ast2600-scu" },
 	{ },
 };
 

--- a/src/soc/scu.c
+++ b/src/soc/scu.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <errno.h>
+
+#include "scu.h"
+
+struct scu {
+	int refcnt;
+	struct soc *soc;
+	struct soc_region regs;
+};
+
+int scu_readl(struct scu *ctx, uint32_t reg, uint32_t *value)
+{
+	return soc_readl(ctx->soc, ctx->regs.start + reg, value);
+}
+
+int scu_writel(struct scu *ctx, uint32_t reg, uint32_t value)
+{
+	return soc_writel(ctx->soc, ctx->regs.start + reg, value);
+}
+
+static int scu_driver_init(struct soc *soc, struct soc_device *dev)
+{
+	struct scu *ctx;
+	int rc;
+
+	ctx = malloc(sizeof(*ctx));
+	if (!ctx) {
+		return -ENOMEM;
+	}
+
+	if ((rc = soc_device_get_memory(soc, &dev->node, &ctx->regs)) < 0) {
+		goto cleanup_ctx;
+	}
+	ctx->refcnt = 1;
+	ctx->soc = soc;
+
+	soc_device_set_drvdata(dev, ctx);
+
+	return 0;
+
+cleanup_ctx:
+	free(ctx);
+	return rc;
+}
+
+static void scu_driver_destroy(struct soc_device *dev)
+{
+	scu_put(soc_device_get_drvdata(dev));
+}
+
+static const struct soc_device_id scu_match[] = {
+	{ .compatible = "aspeed,ast2500-scu" },
+	{ },
+};
+
+static const struct soc_driver scu_driver = {
+	.name = "scu",
+	.matches = scu_match,
+	.init = scu_driver_init,
+	.destroy = scu_driver_destroy,
+};
+REGISTER_SOC_DRIVER(scu_driver);
+
+struct scu *scu_get(struct soc *soc)
+{
+	struct scu *ctx = soc_driver_get_drvdata(soc, &scu_driver);
+	if (ctx) {
+		ctx->refcnt += 1;
+	}
+	return ctx;
+}
+
+void scu_put(struct scu *ctx)
+{
+	ctx->refcnt -= 1;
+	if (!ctx->refcnt) {
+		free(ctx);
+	}
+}

--- a/src/soc/scu.h
+++ b/src/soc/scu.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _SOC_SCU_H
+#define _SOC_SCU_H
+
+#include "soc.h"
+
+struct scu;
+
+struct scu *scu_get(struct soc *soc);
+void scu_put(struct scu *ctx);
+
+int scu_readl(struct scu *ctx, uint32_t reg, uint32_t *val);
+int scu_writel(struct scu *ctx, uint32_t reg, uint32_t val);
+
+#endif


### PR DESCRIPTION
I wasn't sure exactly where the best place to slot in the SCU-unlock was; the strap driver seemed like a slightly less awkward fit than anywhere else I could see, but I'm certainly open to suggestions for a better alternative.

(The first patch is a simple refactor relatively unrelated to the rest of the series aside from the fact that it deals with the strap driver.)
