### PR TITLE
bridge: Use available macros instead of numeric literals

### DIFF
--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -177,8 +177,8 @@ int devmem_init(struct devmem *ctx)
     if (ctx->fd < 0)
         return -errno;
 
-    ctx->io = mmap(NULL, 0x00200000, PROT_READ | PROT_WRITE, MAP_SHARED,
-                   ctx->fd, 0x1e600000);
+    ctx->io = mmap(NULL, AST_SOC_IO_LEN, PROT_READ | PROT_WRITE, MAP_SHARED,
+                   ctx->fd, AST_SOC_IO);
     if (ctx->io == MAP_FAILED) { rc = -errno; goto cleanup_fd; }
 
     ctx->win = NULL;
@@ -200,7 +200,7 @@ int devmem_destroy(struct devmem *ctx)
 
     assert(!ctx->win);
 
-    rc = munmap(ctx->io, 0x00200000);
+    rc = munmap(ctx->io, AST_SOC_IO_LEN);
     if (rc < 0) { perror("munmap"); }
 
     rc = close(ctx->fd);

--- a/src/bridge/l2a.c
+++ b/src/bridge/l2a.c
@@ -178,11 +178,11 @@ int l2ab_destroy(struct l2ab *ctx)
     struct ilpcb *ilpcb = &ctx->ilpcb;
     int rc;
 
-    rc = ilpcb_writel(ilpcb_as_ahb(ilpcb), 0x1e78908c, ctx->restore8);
+    rc = ilpcb_writel(ilpcb_as_ahb(ilpcb), LPC_HICR8, ctx->restore8);
     if (rc)
         return rc;
 
-    rc = ilpcb_writel(ilpcb_as_ahb(ilpcb), 0x1e789088, ctx->restore7);
+    rc = ilpcb_writel(ilpcb_as_ahb(ilpcb), LPC_HICR7, ctx->restore7);
     if (rc)
         return rc;
 


### PR DESCRIPTION
The existing macros were used in a few places, but there were a few remaining instances still using the raw numeric form; clean them up.