### PR TITLE
Improve handling of command-line usage errors

### DIFF
--- a/src/cmd/probe.c
+++ b/src/cmd/probe.c
@@ -78,6 +78,9 @@ int cmd_probe(const char *name, int argc, char *argv[])
                 }
                 break;
             }
+            case '?':
+                rc = EXIT_FAILURE;
+                goto done;
         }
     }
 

--- a/src/cmd/write.c
+++ b/src/cmd/write.c
@@ -63,6 +63,8 @@ int cmd_write(const char *name __unused, int argc, char *argv[])
             case 'l':
                 /* no-op flag retained for backwards compatibility */
                 break;
+            case '?':
+                exit(EXIT_FAILURE);
         }
     }
 

--- a/src/cmd/write.c
+++ b/src/cmd/write.c
@@ -41,7 +41,7 @@ int cmd_write(const char *name __unused, int argc, char *argv[])
     }
 
     if (strcmp("firmware", argv[0])) {
-        loge("Unsupported write type '%s'", argv[0]);
+        loge("Unsupported write type '%s'\n", argv[0]);
         return -EINVAL;
     }
 

--- a/src/culvert.c
+++ b/src/culvert.c
@@ -112,6 +112,8 @@ int main(int argc, char *argv[])
             case 'q':
                 quiet = true;
                 break;
+            case '?':
+                exit(EXIT_FAILURE);
             default:
                 continue;
         }


### PR DESCRIPTION
Exit early if getopt() returns `'?'`, and add a missing `\n` to an error message.