### PR TITLE
Add ability disable specific bridges

### DIFF
--- a/src/ahb.c
+++ b/src/ahb.c
@@ -12,14 +12,6 @@
 #include <string.h>
 #include <unistd.h>
 
-const char *ahb_interface_names[ahb_max_interfaces] = {
-    [ahb_ilpcb] = "iLPC2AHB",
-    [ahb_l2ab] = "LPC2AHB",
-    [ahb_p2ab] = "P2A",
-    [ahb_debug] = "Debug UART",
-    [ahb_devmem] = "devmem",
-};
-
 #define AHB_CHUNK (1 << 20)
 
 ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, size_t len, int outfd)

--- a/src/ahb.h
+++ b/src/ahb.h
@@ -5,23 +5,13 @@
 #define _AHB_H
 
 #include "log.h"
+#include "bridge.h"
 
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
-
-enum ahb_bridge {
-    ahb_ilpcb,
-    ahb_l2ab,
-    ahb_p2ab,
-    ahb_debug,
-    ahb_devmem,
-    ahb_max_interfaces
-};
-
-extern const char *ahb_interface_names[ahb_max_interfaces];
 
 struct ahb_range {
     const char *name;
@@ -40,13 +30,14 @@ struct ahb_ops {
 };
 
 struct ahb {
-    enum ahb_bridge type;
+    const struct bridge_driver *drv;
     const struct ahb_ops *ops;
 };
 
-static inline void ahb_init_ops(struct ahb *ctx, enum ahb_bridge type, const struct ahb_ops *ops)
+static inline void ahb_init_ops(struct ahb *ctx, const struct bridge_driver *drv,
+                                const struct ahb_ops *ops)
 {
-    ctx->type = type;
+    ctx->drv = drv;
     ctx->ops = ops;
 }
 

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -4,15 +4,23 @@
 #ifndef _BRIDGE_H
 #define _BRIDGE_H
 
+#include <stdbool.h>
+
 #include "ahb.h"
 
 #include "ccan/autodata/autodata.h"
 
 struct bridge_driver {
-	enum ahb_bridge type;
+	const char *name;
 	struct ahb *(*probe)(int argc, char *argv[]);
 	int (*reinit)(struct ahb *ahb);
 	void (*destroy)(struct ahb *ahb);
+
+	/*
+	 * Whether or not this driver is for running culvert on the BMC itself
+	 * (i.e. devmem)
+	 */
+	bool local;
 };
 
 AUTODATA_TYPE(bridge_drivers, struct bridge_driver);

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -21,6 +21,9 @@ struct bridge_driver {
 	 * (i.e. devmem)
 	 */
 	bool local;
+
+	/* Set if this driver has been explicitly disabled */
+	bool disabled;
 };
 
 AUTODATA_TYPE(bridge_drivers, struct bridge_driver);

--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -88,7 +88,7 @@ int debug_probe(struct debug *ctx)
 {
     int rc;
 
-    logd("Probing %s\n", ahb_interface_names[ahb_debug]);
+    logd("Probing %s\n", ctx->ahb.drv->name);
 
     rc = debug_enter(ctx);
     if (rc < 0)
@@ -445,6 +445,16 @@ static const struct ahb_ops debug_ahb_ops = {
     .writel = debug_writel
 };
 
+static struct ahb *debug_driver_probe(int argc, char *argv[]);
+static void debug_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver debug_driver = {
+    .name = "debug-uart",
+    .probe = debug_driver_probe,
+    .destroy = debug_driver_destroy,
+};
+REGISTER_BRIDGE_DRIVER(debug_driver);
+
 int debug_init_v(struct debug *ctx, va_list args)
 {
     const char *interface;
@@ -478,7 +488,7 @@ int debug_init_v(struct debug *ctx, va_list args)
     rc = prompt_init(&ctx->prompt, fd, "\r", false);
     if (rc < 0) { goto cleanup_ts16; }
 
-    ahb_init_ops(&ctx->ahb, ahb_debug, &debug_ahb_ops);
+    ahb_init_ops(&ctx->ahb, &debug_driver, &debug_ahb_ops);
 
     return 0;
 
@@ -559,10 +569,3 @@ static void debug_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver debug_driver = {
-    .type = ahb_debug,
-    .probe = debug_driver_probe,
-    .destroy = debug_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(debug_driver);

--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -448,7 +448,7 @@ static const struct ahb_ops debug_ahb_ops = {
 static struct ahb *debug_driver_probe(int argc, char *argv[]);
 static void debug_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver debug_driver = {
+static struct bridge_driver debug_driver = {
     .name = "debug-uart",
     .probe = debug_driver_probe,
     .destroy = debug_driver_destroy,

--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -33,7 +33,7 @@ int devmem_probe(struct devmem *ctx)
 {
     int rc;
 
-    logd("Probing %s\n", ahb_interface_names[ahb_devmem]);
+    logd("Probing %s\n", ctx->ahb.drv->name);
 
 #ifndef __arm__
     return -ENOTSUP;
@@ -166,6 +166,17 @@ static const struct ahb_ops devmem_ahb_ops = {
     .writel = devmem_writel
 };
 
+static struct ahb *devmem_driver_probe(int argc, char *argv[]);
+static void devmem_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver devmem_driver = {
+    .name = "devmem",
+    .probe = devmem_driver_probe,
+    .destroy = devmem_driver_destroy,
+    .local = true,
+};
+REGISTER_BRIDGE_DRIVER(devmem_driver);
+
 int devmem_init(struct devmem *ctx)
 {
     int cleanup;
@@ -183,7 +194,7 @@ int devmem_init(struct devmem *ctx)
 
     ctx->win = NULL;
 
-    ahb_init_ops(&ctx->ahb, ahb_devmem, &devmem_ahb_ops);
+    ahb_init_ops(&ctx->ahb, &devmem_driver, &devmem_ahb_ops);
 
     return 0;
 
@@ -257,10 +268,3 @@ static void devmem_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver devmem_driver = {
-    .type = ahb_devmem,
-    .probe = devmem_driver_probe,
-    .destroy = devmem_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(devmem_driver);

--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -169,7 +169,7 @@ static const struct ahb_ops devmem_ahb_ops = {
 static struct ahb *devmem_driver_probe(int argc, char *argv[]);
 static void devmem_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver devmem_driver = {
+static struct bridge_driver devmem_driver = {
     .name = "devmem",
     .probe = devmem_driver_probe,
     .destroy = devmem_driver_destroy,

--- a/src/bridge/ilpc.c
+++ b/src/bridge/ilpc.c
@@ -24,7 +24,7 @@ int ilpcb_probe(struct ilpcb *ctx)
 {
     int rc;
 
-    logd("Probing %s\n", ahb_interface_names[ahb_ilpcb]);
+    logd("Probing %s\n", ctx->ahb.drv->name);
 
     if (!sio_probe(&ctx->sio))
         return 0;
@@ -308,9 +308,19 @@ static const struct ahb_ops ilpcb_ops = {
     .writel = ilpcb_writel
 };
 
+static struct ahb *ilpcb_driver_probe(int argc, char *argv[]);
+static void ilpcb_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver ilpcb_driver = {
+    .name = "ilpc",
+    .probe = ilpcb_driver_probe,
+    .destroy = ilpcb_driver_destroy,
+};
+REGISTER_BRIDGE_DRIVER(ilpcb_driver);
+
 int ilpcb_init(struct ilpcb *ctx)
 {
-    ahb_init_ops(&ctx->ahb, ahb_ilpcb, &ilpcb_ops);
+    ahb_init_ops(&ctx->ahb, &ilpcb_driver, &ilpcb_ops);
 
     return sio_init(&ctx->sio);
 }
@@ -368,10 +378,3 @@ static void ilpcb_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver ilpcb_driver = {
-    .type = ahb_ilpcb,
-    .probe = ilpcb_driver_probe,
-    .destroy = ilpcb_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(ilpcb_driver);

--- a/src/bridge/ilpc.c
+++ b/src/bridge/ilpc.c
@@ -311,7 +311,7 @@ static const struct ahb_ops ilpcb_ops = {
 static struct ahb *ilpcb_driver_probe(int argc, char *argv[]);
 static void ilpcb_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver ilpcb_driver = {
+static struct bridge_driver ilpcb_driver = {
     .name = "ilpc",
     .probe = ilpcb_driver_probe,
     .destroy = ilpcb_driver_destroy,

--- a/src/bridge/l2a.c
+++ b/src/bridge/l2a.c
@@ -140,7 +140,7 @@ static const struct ahb_ops l2ab_ahb_ops = {
 static struct ahb *l2ab_driver_probe(int argc, char *argv[]);
 static void l2ab_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver l2ab_driver = {
+static struct bridge_driver l2ab_driver = {
     .name = "l2a",
     .probe = l2ab_driver_probe,
     .destroy = l2ab_driver_destroy,

--- a/src/bridge/l2a.c
+++ b/src/bridge/l2a.c
@@ -137,6 +137,16 @@ static const struct ahb_ops l2ab_ahb_ops = {
     .writel = l2ab_writel,
 };
 
+static struct ahb *l2ab_driver_probe(int argc, char *argv[]);
+static void l2ab_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver l2ab_driver = {
+    .name = "l2a",
+    .probe = l2ab_driver_probe,
+    .destroy = l2ab_driver_destroy,
+};
+REGISTER_BRIDGE_DRIVER(l2ab_driver);
+
 int l2ab_init(struct l2ab *ctx)
 {
     struct ilpcb *ilpcb = &ctx->ilpcb;
@@ -162,7 +172,7 @@ int l2ab_init(struct l2ab *ctx)
     if (rc)
         goto cleanup;
 
-    ahb_init_ops(&ctx->ahb, ahb_l2ab, &l2ab_ahb_ops);
+    ahb_init_ops(&ctx->ahb, &l2ab_driver, &l2ab_ahb_ops);
 
     return 0;
 
@@ -233,10 +243,3 @@ static void l2ab_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver l2ab_driver = {
-    .type = ahb_l2ab,
-    .probe = l2ab_driver_probe,
-    .destroy = l2ab_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(l2ab_driver);

--- a/src/bridge/p2a.c
+++ b/src/bridge/p2a.c
@@ -203,7 +203,7 @@ static struct ahb *p2ab_driver_probe(int argc, char *argv[]);
 static int p2ab_driver_reinit(struct ahb *ahb);
 static void p2ab_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver p2ab_driver = {
+static struct bridge_driver p2ab_driver = {
     .name = "p2a",
     .probe = p2ab_driver_probe,
     .reinit = p2ab_driver_reinit,

--- a/src/cmd/reset.c
+++ b/src/cmd/reset.c
@@ -67,7 +67,7 @@ int cmd_reset(const char *name __unused, int argc, char *argv[])
     }
 
     /* Do the reset */
-    if (ahb->type != ahb_devmem) {
+    if (!ahb->drv->local) {
         logi("Gating ARM clock\n");
         rc = clk_disable(clk, clk_arm);
         if (rc < 0)

--- a/src/cmd/write.c
+++ b/src/cmd/write.c
@@ -95,7 +95,7 @@ int cmd_write(const char *name __unused, int argc, char *argv[])
         goto cleanup_soc;
     }
 
-    if (ahb->type == ahb_devmem)
+    if (ahb->drv->local)
         loge("I hope you know what you are doing\n");
     else {
         logi("Preventing system reset\n");
@@ -161,7 +161,7 @@ cleanup_flash:
 
 cleanup_state:
     if (rc == 0) {
-        if (ahb->type != ahb_devmem) {
+        if (!ahb->drv->local) {
             struct wdt *wdt;
             int64_t wait;
 

--- a/src/culvert.c
+++ b/src/culvert.c
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
 
     if (optind == argc) {
         if (!show_help)
-            loge("Not enough arguments\n");
+            fprintf(stderr, "Error: not enough arguments\n");
         help(program_invocation_short_name);
         exit(EXIT_FAILURE);
     }
@@ -150,6 +150,6 @@ int main(int argc, char *argv[])
         cmd++;
     }
 
-    loge("Unknown command: %s\n", argv[1]);
+    fprintf(stderr, "Error: unknown command: %s\n", argv[1]);
     exit(EXIT_FAILURE);
 }

--- a/src/host.c
+++ b/src/host.c
@@ -36,7 +36,7 @@ int host_init(struct host *ctx, int argc, char *argv[])
     for (i = 0; i < n_bridges; i++) {
         struct ahb *ahb;
 
-        logd("Trying bridge driver %s\n", ahb_interface_names[bridges[i]->type]);
+        logd("Trying bridge driver %s\n", bridges[i]->name);
 
         if ((ahb = bridges[i]->probe(argc, argv))) {
             struct bridge *bridge;

--- a/src/host.h
+++ b/src/host.h
@@ -12,6 +12,8 @@ struct host {
 	struct list_head bridges;
 };
 
+int on_each_bridge_driver(int (*fn)(struct bridge_driver*, void*), void *arg);
+
 int host_init(struct host *ctx, int argc, char *argv[]);
 void host_destroy(struct host *ctx);
 


### PR DESCRIPTION
On some hardware probing some bridges can cause violent host crashes; these patches add a `--skip-bridge` flag to allow disabling problematic ones.