### PR TITLE
Watchdog reset fixes

### DIFF
--- a/src/cmd/reset.c
+++ b/src/cmd/reset.c
@@ -20,7 +20,6 @@ int cmd_reset(const char *name __unused, int argc, char *argv[])
 {
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
-    int64_t wait = 0;
     struct ahb *ahb;
     struct clk *clk;
     struct wdt *wdt;
@@ -83,11 +82,8 @@ int cmd_reset(const char *name __unused, int argc, char *argv[])
 
     /* wdt_perform_reset ungates the ARM if required */
     logi("Performing SoC reset\n");
-    if ((wait = wdt_perform_reset(wdt)) > 0)
-        usleep(wait);
-
-    /* Cleanup */
-    if (wait < 0) {
+    rc = wdt_perform_reset(wdt);
+    if (rc < 0) {
 clk_enable_arm:
         if ((cleanup = clk_enable(clk, clk_arm)) < 0) {
             errno = -cleanup;

--- a/src/cmd/write.c
+++ b/src/cmd/write.c
@@ -163,7 +163,6 @@ cleanup_state:
     if (rc == 0) {
         if (ahb->type != ahb_devmem) {
             struct wdt *wdt;
-            int64_t wait;
 
             logi("Performing SoC reset\n");
             if (!(wdt = wdt_get_by_name(soc, "wdt2"))) {
@@ -171,14 +170,9 @@ cleanup_state:
                 goto cleanup_soc;
             }
 
-            wait = wdt_perform_reset(wdt);
-
-            if (wait < 0) {
-                rc = wait;
+            rc = wdt_perform_reset(wdt);
+            if (rc < 0)
                 goto cleanup_soc;
-            }
-
-            usleep(wait);
         }
     } else {
         logi("Deconfiguring VUART host Tx discard\n");

--- a/src/soc/wdt.c
+++ b/src/soc/wdt.c
@@ -12,6 +12,8 @@
 
 /* Registers */
 #define WDT_RELOAD	        0x04
+#define WDT_RESTART	        0x08
+#define   WDT_RESTART_MAGIC     0x4755
 #define WDT_CTRL	        0x0c
 #define   WDT_CTRL_ALT_BOOT     (1 << 7)
 #define   WDT_CTRL_RESET_SOC    (0b00 << 5)
@@ -141,6 +143,10 @@ int64_t wdt_perform_reset(struct wdt *ctx)
         return wait;
 
     rc = wdt_writel(ctx, WDT_RELOAD, wait);
+    if (rc < 0)
+        return rc;
+
+    rc = wdt_writel(ctx, WDT_RESTART, WDT_RESTART_MAGIC);
     if (rc < 0)
         return rc;
 

--- a/src/soc/wdt.c
+++ b/src/soc/wdt.c
@@ -13,8 +13,7 @@
 /* Registers */
 #define WDT_RELOAD	        0x04
 #define WDT_CTRL	        0x0c
-#define   WDT_CTRL_BOOT_1       (0 << 7)
-#define   WDT_CTRL_BOOT_2       (1 << 7)
+#define   WDT_CTRL_ALT_BOOT     (1 << 7)
 #define   WDT_CTRL_RESET_SOC    (0b00 << 5)
 #define   WDT_CTRL_RESET_SYS    (0b01 << 5)
 #define   WDT_CTRL_RESET_CPU    (0b10 << 5)
@@ -149,6 +148,7 @@ int64_t wdt_perform_reset(struct wdt *ctx)
         return rc;
 
     mode |= WDT_CTRL_RESET_SOC | WDT_CTRL_SYS_RESET | WDT_CTRL_ENABLE;
+    mode &= ~WDT_CTRL_ALT_BOOT;
 
     if ((rc = wdt_writel(ctx, WDT_CTRL, mode)) < 0)
         return rc;

--- a/src/soc/wdt.c
+++ b/src/soc/wdt.c
@@ -9,6 +9,7 @@
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <unistd.h>
 
 /* Registers */
 #define WDT_RELOAD	        0x04
@@ -119,7 +120,7 @@ static int64_t wdt_usecs_to_ticks(struct wdt *ctx, uint32_t usecs)
     return usecs;
 }
 
-int64_t wdt_perform_reset(struct wdt *ctx)
+int wdt_perform_reset(struct wdt *ctx)
 {
     uint32_t mode;
     int64_t wait;
@@ -159,6 +160,9 @@ int64_t wdt_perform_reset(struct wdt *ctx)
     if ((rc = wdt_writel(ctx, WDT_CTRL, mode)) < 0)
         return rc;
 
+    logd("Waiting %"PRId64" microseconds for watchdog timer to expire\n", wait);
+    usleep(wait);
+
     /* The ARM clock gate is sticky on reset?! Ensure it's clear  */
     if ((rc = clk_enable(ctx->clk, clk_arm)) < 0)
         return rc;
@@ -167,7 +171,7 @@ int64_t wdt_perform_reset(struct wdt *ctx)
     if (rc < 0)
         return rc;
 
-    return wait;
+    return 0;
 }
 
 static const struct soc_device_id wdt_match[] = {

--- a/src/soc/wdt.h
+++ b/src/soc/wdt.h
@@ -12,7 +12,7 @@ int wdt_prevent_reset(struct soc *soc);
 struct wdt;
 
 int wdt_init(struct wdt *ctx, struct soc *soc, const char *name);
-int64_t wdt_perform_reset(struct wdt *ctx);
+int wdt_perform_reset(struct wdt *ctx);
 void wdt_destroy(struct wdt *ctx);
 
 struct wdt *wdt_get_by_name(struct soc *soc, const char *name);


### PR DESCRIPTION
These patches address a few problems with the existing wdt reset mechanism.

 - Watchdog behavior w.r.t. selecting the default or alternate boot source had previously been unpredictable; the first patch ensures the default boot source is always used.

 - The existing code didn't actually load the desired value into the counter register and hence didn't end up with the reset occurring at the intended time; the second patch uses the counter-restart register to make the reload take effect.

 - Previously we were un-gating the ARM clock immediately after starting the watchdog timer instead of waiting for it to expire; the third patch makes the reset code path responsible for sleeping for the programmed timer interval before re-enabling the ARM core.