### PR TITLE
Bridge disabling, wdt fixes, etc.

### DIFF
--- a/src/ahb.c
+++ b/src/ahb.c
@@ -12,14 +12,6 @@
 #include <string.h>
 #include <unistd.h>
 
-const char *ahb_interface_names[ahb_max_interfaces] = {
-    [ahb_ilpcb] = "iLPC2AHB",
-    [ahb_l2ab] = "LPC2AHB",
-    [ahb_p2ab] = "P2A",
-    [ahb_debug] = "Debug UART",
-    [ahb_devmem] = "devmem",
-};
-
 #define AHB_CHUNK (1 << 20)
 
 ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, size_t len, int outfd)

--- a/src/ahb.c
+++ b/src/ahb.c
@@ -83,3 +83,13 @@ done:
 
     return rc;
 }
+
+int ahb_release_bridge(struct ahb *ctx)
+{
+    return ctx->drv->release ? ctx->drv->release(ctx) : 0;
+}
+
+int ahb_reinit_bridge(struct ahb *ctx)
+{
+    return ctx->drv->reinit ? ctx->drv->reinit(ctx) : 0;
+}

--- a/src/ahb.h
+++ b/src/ahb.h
@@ -5,23 +5,13 @@
 #define _AHB_H
 
 #include "log.h"
+#include "bridge.h"
 
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
-
-enum ahb_bridge {
-    ahb_ilpcb,
-    ahb_l2ab,
-    ahb_p2ab,
-    ahb_debug,
-    ahb_devmem,
-    ahb_max_interfaces
-};
-
-extern const char *ahb_interface_names[ahb_max_interfaces];
 
 struct ahb_range {
     const char *name;
@@ -40,13 +30,14 @@ struct ahb_ops {
 };
 
 struct ahb {
-    enum ahb_bridge type;
+    const struct bridge_driver *drv;
     const struct ahb_ops *ops;
 };
 
-static inline void ahb_init_ops(struct ahb *ctx, enum ahb_bridge type, const struct ahb_ops *ops)
+static inline void ahb_init_ops(struct ahb *ctx, const struct bridge_driver *drv,
+                                const struct ahb_ops *ops)
 {
-    ctx->type = type;
+    ctx->drv = drv;
     ctx->ops = ops;
 }
 

--- a/src/ahb.h
+++ b/src/ahb.h
@@ -75,4 +75,7 @@ static inline int ahb_writel(struct ahb *ctx, uint32_t phys, uint32_t val)
 ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, size_t len, int outfd);
 ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, int infd);
 
+int ahb_release_bridge(struct ahb *ctx);
+int ahb_reinit_bridge(struct ahb *ctx);
+
 #endif

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -4,15 +4,23 @@
 #ifndef _BRIDGE_H
 #define _BRIDGE_H
 
+#include <stdbool.h>
+
 #include "ahb.h"
 
 #include "ccan/autodata/autodata.h"
 
 struct bridge_driver {
-	enum ahb_bridge type;
+	const char *name;
 	struct ahb *(*probe)(int argc, char *argv[]);
 	int (*reinit)(struct ahb *ahb);
 	void (*destroy)(struct ahb *ahb);
+
+	/*
+	 * Whether or not this driver is for running culvert on the BMC itself
+	 * (i.e. devmem)
+	 */
+	bool local;
 };
 
 AUTODATA_TYPE(bridge_drivers, struct bridge_driver);

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -21,6 +21,9 @@ struct bridge_driver {
 	 * (i.e. devmem)
 	 */
 	bool local;
+
+	/* Set if this driver has been explicitly disabled */
+	bool disabled;
 };
 
 AUTODATA_TYPE(bridge_drivers, struct bridge_driver);

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -13,6 +13,7 @@
 struct bridge_driver {
 	const char *name;
 	struct ahb *(*probe)(int argc, char *argv[]);
+	int (*release)(struct ahb *ahb);
 	int (*reinit)(struct ahb *ahb);
 	void (*destroy)(struct ahb *ahb);
 

--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -447,11 +447,15 @@ static const struct ahb_ops debug_ahb_ops = {
 
 static struct ahb *debug_driver_probe(int argc, char *argv[]);
 static void debug_driver_destroy(struct ahb *ahb);
+static int debug_driver_release(struct ahb *ahb);
+static int debug_driver_reinit(struct ahb *ahb);
 
 static struct bridge_driver debug_driver = {
     .name = "debug-uart",
     .probe = debug_driver_probe,
     .destroy = debug_driver_destroy,
+    .release = debug_driver_release,
+    .reinit = debug_driver_reinit,
 };
 REGISTER_BRIDGE_DRIVER(debug_driver);
 
@@ -568,4 +572,18 @@ static void debug_driver_destroy(struct ahb *ahb)
     }
 
     free(ctx);
+}
+
+static int debug_driver_release(struct ahb *ahb)
+{
+    struct debug *ctx = to_debug(ahb);
+
+    return debug_exit(ctx);
+}
+
+static int debug_driver_reinit(struct ahb *ahb)
+{
+    struct debug *ctx = to_debug(ahb);
+
+    return debug_enter(ctx);
 }

--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -88,7 +88,7 @@ int debug_probe(struct debug *ctx)
 {
     int rc;
 
-    logd("Probing %s\n", ahb_interface_names[ahb_debug]);
+    logd("Probing %s\n", ctx->ahb.drv->name);
 
     rc = debug_enter(ctx);
     if (rc < 0)
@@ -445,6 +445,16 @@ static const struct ahb_ops debug_ahb_ops = {
     .writel = debug_writel
 };
 
+static struct ahb *debug_driver_probe(int argc, char *argv[]);
+static void debug_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver debug_driver = {
+    .name = "debug-uart",
+    .probe = debug_driver_probe,
+    .destroy = debug_driver_destroy,
+};
+REGISTER_BRIDGE_DRIVER(debug_driver);
+
 int debug_init_v(struct debug *ctx, va_list args)
 {
     const char *interface;
@@ -478,7 +488,7 @@ int debug_init_v(struct debug *ctx, va_list args)
     rc = prompt_init(&ctx->prompt, fd, "\r", false);
     if (rc < 0) { goto cleanup_ts16; }
 
-    ahb_init_ops(&ctx->ahb, ahb_debug, &debug_ahb_ops);
+    ahb_init_ops(&ctx->ahb, &debug_driver, &debug_ahb_ops);
 
     return 0;
 
@@ -559,10 +569,3 @@ static void debug_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver debug_driver = {
-    .type = ahb_debug,
-    .probe = debug_driver_probe,
-    .destroy = debug_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(debug_driver);

--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -448,7 +448,7 @@ static const struct ahb_ops debug_ahb_ops = {
 static struct ahb *debug_driver_probe(int argc, char *argv[]);
 static void debug_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver debug_driver = {
+static struct bridge_driver debug_driver = {
     .name = "debug-uart",
     .probe = debug_driver_probe,
     .destroy = debug_driver_destroy,

--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -33,7 +33,7 @@ int devmem_probe(struct devmem *ctx)
 {
     int rc;
 
-    logd("Probing %s\n", ahb_interface_names[ahb_devmem]);
+    logd("Probing %s\n", ctx->ahb.drv->name);
 
 #ifndef __arm__
     return -ENOTSUP;
@@ -166,6 +166,17 @@ static const struct ahb_ops devmem_ahb_ops = {
     .writel = devmem_writel
 };
 
+static struct ahb *devmem_driver_probe(int argc, char *argv[]);
+static void devmem_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver devmem_driver = {
+    .name = "devmem",
+    .probe = devmem_driver_probe,
+    .destroy = devmem_driver_destroy,
+    .local = true,
+};
+REGISTER_BRIDGE_DRIVER(devmem_driver);
+
 int devmem_init(struct devmem *ctx)
 {
     int cleanup;
@@ -183,7 +194,7 @@ int devmem_init(struct devmem *ctx)
 
     ctx->win = NULL;
 
-    ahb_init_ops(&ctx->ahb, ahb_devmem, &devmem_ahb_ops);
+    ahb_init_ops(&ctx->ahb, &devmem_driver, &devmem_ahb_ops);
 
     return 0;
 
@@ -257,10 +268,3 @@ static void devmem_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver devmem_driver = {
-    .type = ahb_devmem,
-    .probe = devmem_driver_probe,
-    .destroy = devmem_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(devmem_driver);

--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -169,7 +169,7 @@ static const struct ahb_ops devmem_ahb_ops = {
 static struct ahb *devmem_driver_probe(int argc, char *argv[]);
 static void devmem_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver devmem_driver = {
+static struct bridge_driver devmem_driver = {
     .name = "devmem",
     .probe = devmem_driver_probe,
     .destroy = devmem_driver_destroy,

--- a/src/bridge/ilpc.c
+++ b/src/bridge/ilpc.c
@@ -24,7 +24,7 @@ int ilpcb_probe(struct ilpcb *ctx)
 {
     int rc;
 
-    logd("Probing %s\n", ahb_interface_names[ahb_ilpcb]);
+    logd("Probing %s\n", ctx->ahb.drv->name);
 
     if (!sio_probe(&ctx->sio))
         return 0;
@@ -308,9 +308,19 @@ static const struct ahb_ops ilpcb_ops = {
     .writel = ilpcb_writel
 };
 
+static struct ahb *ilpcb_driver_probe(int argc, char *argv[]);
+static void ilpcb_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver ilpcb_driver = {
+    .name = "ilpc",
+    .probe = ilpcb_driver_probe,
+    .destroy = ilpcb_driver_destroy,
+};
+REGISTER_BRIDGE_DRIVER(ilpcb_driver);
+
 int ilpcb_init(struct ilpcb *ctx)
 {
-    ahb_init_ops(&ctx->ahb, ahb_ilpcb, &ilpcb_ops);
+    ahb_init_ops(&ctx->ahb, &ilpcb_driver, &ilpcb_ops);
 
     return sio_init(&ctx->sio);
 }
@@ -368,10 +378,3 @@ static void ilpcb_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver ilpcb_driver = {
-    .type = ahb_ilpcb,
-    .probe = ilpcb_driver_probe,
-    .destroy = ilpcb_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(ilpcb_driver);

--- a/src/bridge/ilpc.c
+++ b/src/bridge/ilpc.c
@@ -311,7 +311,7 @@ static const struct ahb_ops ilpcb_ops = {
 static struct ahb *ilpcb_driver_probe(int argc, char *argv[]);
 static void ilpcb_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver ilpcb_driver = {
+static struct bridge_driver ilpcb_driver = {
     .name = "ilpc",
     .probe = ilpcb_driver_probe,
     .destroy = ilpcb_driver_destroy,

--- a/src/bridge/l2a.c
+++ b/src/bridge/l2a.c
@@ -140,7 +140,7 @@ static const struct ahb_ops l2ab_ahb_ops = {
 static struct ahb *l2ab_driver_probe(int argc, char *argv[]);
 static void l2ab_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver l2ab_driver = {
+static struct bridge_driver l2ab_driver = {
     .name = "l2a",
     .probe = l2ab_driver_probe,
     .destroy = l2ab_driver_destroy,

--- a/src/bridge/l2a.c
+++ b/src/bridge/l2a.c
@@ -137,6 +137,16 @@ static const struct ahb_ops l2ab_ahb_ops = {
     .writel = l2ab_writel,
 };
 
+static struct ahb *l2ab_driver_probe(int argc, char *argv[]);
+static void l2ab_driver_destroy(struct ahb *ahb);
+
+static const struct bridge_driver l2ab_driver = {
+    .name = "l2a",
+    .probe = l2ab_driver_probe,
+    .destroy = l2ab_driver_destroy,
+};
+REGISTER_BRIDGE_DRIVER(l2ab_driver);
+
 int l2ab_init(struct l2ab *ctx)
 {
     struct ilpcb *ilpcb = &ctx->ilpcb;
@@ -162,7 +172,7 @@ int l2ab_init(struct l2ab *ctx)
     if (rc)
         goto cleanup;
 
-    ahb_init_ops(&ctx->ahb, ahb_l2ab, &l2ab_ahb_ops);
+    ahb_init_ops(&ctx->ahb, &l2ab_driver, &l2ab_ahb_ops);
 
     return 0;
 
@@ -233,10 +243,3 @@ static void l2ab_driver_destroy(struct ahb *ahb)
 
     free(ctx);
 }
-
-static const struct bridge_driver l2ab_driver = {
-    .type = ahb_l2ab,
-    .probe = l2ab_driver_probe,
-    .destroy = l2ab_driver_destroy,
-};
-REGISTER_BRIDGE_DRIVER(l2ab_driver);

--- a/src/bridge/p2a.c
+++ b/src/bridge/p2a.c
@@ -203,7 +203,7 @@ static struct ahb *p2ab_driver_probe(int argc, char *argv[]);
 static int p2ab_driver_reinit(struct ahb *ahb);
 static void p2ab_driver_destroy(struct ahb *ahb);
 
-static const struct bridge_driver p2ab_driver = {
+static struct bridge_driver p2ab_driver = {
     .name = "p2a",
     .probe = p2ab_driver_probe,
     .reinit = p2ab_driver_reinit,

--- a/src/cmd/reset.c
+++ b/src/cmd/reset.c
@@ -20,7 +20,6 @@ int cmd_reset(const char *name __unused, int argc, char *argv[])
 {
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
-    int64_t wait = 0;
     struct ahb *ahb;
     struct clk *clk;
     struct wdt *wdt;
@@ -83,11 +82,8 @@ int cmd_reset(const char *name __unused, int argc, char *argv[])
 
     /* wdt_perform_reset ungates the ARM if required */
     logi("Performing SoC reset\n");
-    if ((wait = wdt_perform_reset(wdt)) > 0)
-        usleep(wait);
-
-    /* Cleanup */
-    if (wait < 0) {
+    rc = wdt_perform_reset(wdt);
+    if (rc < 0) {
 clk_enable_arm:
         if ((cleanup = clk_enable(clk, clk_arm)) < 0) {
             errno = -cleanup;

--- a/src/cmd/reset.c
+++ b/src/cmd/reset.c
@@ -67,7 +67,7 @@ int cmd_reset(const char *name __unused, int argc, char *argv[])
     }
 
     /* Do the reset */
-    if (ahb->type != ahb_devmem) {
+    if (!ahb->drv->local) {
         logi("Gating ARM clock\n");
         rc = clk_disable(clk, clk_arm);
         if (rc < 0)

--- a/src/cmd/trace.c
+++ b/src/cmd/trace.c
@@ -111,7 +111,7 @@ int cmd_trace(const char *name __unused, int argc, char *argv[])
      * between when we start tracing and when we stop. Especially if other functions
      * of this tool are being used. Work around that by re-initing the bridge.
      */
-    if ((rc = host_bridge_reinit_from_ahb(host, ahb)) < 0) {
+    if ((rc = host_bridge_reinit_from_ahb(ahb)) < 0) {
         loge("Failed to reinitialise AHB bridge: %d\n", rc);
         goto cleanup_soc;
     }

--- a/src/cmd/trace.c
+++ b/src/cmd/trace.c
@@ -98,6 +98,18 @@ int cmd_trace(const char *name __unused, int argc, char *argv[])
         goto cleanup_soc;
     }
 
+    /*
+     * The trace command waits for an unbounded amount of time while the trace
+     * is collected; it's possible the bridge state may change while we're
+     * waiting (for example if other culvert functions are being used).  We
+     * attempt to handle this gracefully by releasing the bridge and then
+     * reinitializing it later when we need to dump the trace.
+     */
+    if ((rc = host_bridge_release_from_ahb(ahb)) < 0) {
+        loge("Failed to release AHB bridge: %d\n", rc);
+        goto cleanup_soc;
+    }
+
     sigprocmask(SIG_BLOCK, &set, NULL);
     if ((rc = sigwait(&set, &sig))) {
         rc = -rc;
@@ -106,11 +118,6 @@ int cmd_trace(const char *name __unused, int argc, char *argv[])
     }
     sigprocmask(SIG_UNBLOCK, &set, NULL);
 
-    /*
-     * The trace app is long-lived so it's possible the bridge state has changed
-     * between when we start tracing and when we stop. Especially if other functions
-     * of this tool are being used. Work around that by re-initing the bridge.
-     */
     if ((rc = host_bridge_reinit_from_ahb(ahb)) < 0) {
         loge("Failed to reinitialise AHB bridge: %d\n", rc);
         goto cleanup_soc;

--- a/src/cmd/write.c
+++ b/src/cmd/write.c
@@ -163,7 +163,6 @@ cleanup_state:
     if (rc == 0) {
         if (!ahb->drv->local) {
             struct wdt *wdt;
-            int64_t wait;
 
             logi("Performing SoC reset\n");
             if (!(wdt = wdt_get_by_name(soc, "wdt2"))) {
@@ -171,14 +170,9 @@ cleanup_state:
                 goto cleanup_soc;
             }
 
-            wait = wdt_perform_reset(wdt);
-
-            if (wait < 0) {
-                rc = wait;
+            rc = wdt_perform_reset(wdt);
+            if (rc < 0)
                 goto cleanup_soc;
-            }
-
-            usleep(wait);
         }
     } else {
         logi("Deconfiguring VUART host Tx discard\n");

--- a/src/cmd/write.c
+++ b/src/cmd/write.c
@@ -95,7 +95,7 @@ int cmd_write(const char *name __unused, int argc, char *argv[])
         goto cleanup_soc;
     }
 
-    if (ahb->type == ahb_devmem)
+    if (ahb->drv->local)
         loge("I hope you know what you are doing\n");
     else {
         logi("Preventing system reset\n");
@@ -161,7 +161,7 @@ cleanup_flash:
 
 cleanup_state:
     if (rc == 0) {
-        if (ahb->type != ahb_devmem) {
+        if (!ahb->drv->local) {
             struct wdt *wdt;
             int64_t wait;
 

--- a/src/culvert.c
+++ b/src/culvert.c
@@ -13,8 +13,11 @@
 #include <string.h>
 
 #include "config.h"
+#include "compiler.h"
 #include "log.h"
 #include "version.h"
+#include "ahb.h"
+#include "host.h"
 
 int cmd_ilpc(const char *name, int argc, char *argv[]);
 int cmd_p2a(const char *name, int argc, char *argv[]);
@@ -98,6 +101,8 @@ int main(int argc, char *argv[])
         static struct option long_options[] = {
             { "help", no_argument, NULL, 'h' },
             { "quiet", no_argument, NULL, 'q' },
+            { "skip-bridge", required_argument, NULL, 's' },
+            { "list-bridges", no_argument, NULL, 'l' },
             { "verbose", no_argument, NULL, 'v' },
             { "version", no_argument, NULL, 'V' },
             { },
@@ -105,13 +110,17 @@ int main(int argc, char *argv[])
         int option_index = 0;
         int c;
 
-        c = getopt_long(argc, argv, "+hqvV", long_options, &option_index);
+        c = getopt_long(argc, argv, "+hlqs:vV", long_options, &option_index);
         if (c == -1)
             break;
 
         switch (c) {
             case 'h':
                 show_help = true;
+                break;
+            case 'l':
+                print_bridge_drivers();
+                exit(EXIT_SUCCESS);
                 break;
             case 'v':
                 verbose++;
@@ -121,6 +130,12 @@ int main(int argc, char *argv[])
                 exit(EXIT_SUCCESS);
             case 'q':
                 quiet = true;
+                break;
+            case 's':
+                if (disable_bridge_driver(optarg)) {
+                    fprintf(stderr, "Error: '%s' not a recognized bridge name (use '-l' to list)\n", optarg);
+                    exit(EXIT_FAILURE);
+                }
                 break;
             case '?':
                 exit(EXIT_FAILURE);

--- a/src/culvert.c
+++ b/src/culvert.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 
     if (optind == argc) {
         if (!show_help)
-            loge("Not enough arguments\n");
+            fprintf(stderr, "Error: not enough arguments\n");
         print_help(program_invocation_short_name);
         exit(EXIT_FAILURE);
     }
@@ -160,6 +160,6 @@ int main(int argc, char *argv[])
         cmd++;
     }
 
-    loge("Unknown command: %s\n", argv[1]);
+    fprintf(stderr, "Error: unknown command: %s\n", argv[1]);
     exit(EXIT_FAILURE);
 }

--- a/src/host.c
+++ b/src/host.c
@@ -36,7 +36,7 @@ int host_init(struct host *ctx, int argc, char *argv[])
     for (i = 0; i < n_bridges; i++) {
         struct ahb *ahb;
 
-        logd("Trying bridge driver %s\n", ahb_interface_names[bridges[i]->type]);
+        logd("Trying bridge driver %s\n", bridges[i]->name);
 
         if ((ahb = bridges[i]->probe(argc, argv))) {
             struct bridge *bridge;
@@ -80,19 +80,4 @@ struct ahb *host_get_ahb(struct host *ctx)
     bridge = list_top(&ctx->bridges, struct bridge, entry);
 
     return bridge ? bridge->ahb : NULL;
-}
-
-int host_bridge_reinit_from_ahb(struct host *ctx, struct ahb *ahb)
-{
-    struct bridge *bridge, *next;
-
-    list_for_each_safe(&ctx->bridges, bridge, next, entry) {
-        if (bridge->ahb != ahb) {
-            continue;
-        }
-
-        return bridge->driver->reinit ? bridge->driver->reinit(bridge->ahb) : 0;
-    }
-
-    return 0;
 }

--- a/src/host.h
+++ b/src/host.h
@@ -15,6 +15,9 @@ struct host {
 int host_init(struct host *ctx, int argc, char *argv[]);
 void host_destroy(struct host *ctx);
 
+int disable_bridge_driver(const char *drv);
+void print_bridge_drivers(void);
+
 struct ahb *host_get_ahb(struct host *ctx);
 static inline int host_bridge_reinit_from_ahb(struct ahb *ahb)
 {

--- a/src/host.h
+++ b/src/host.h
@@ -19,6 +19,12 @@ int disable_bridge_driver(const char *drv);
 void print_bridge_drivers(void);
 
 struct ahb *host_get_ahb(struct host *ctx);
+
+static inline int host_bridge_release_from_ahb(struct ahb *ahb)
+{
+	return ahb->drv->release ? ahb->drv->release(ahb) : 0;
+}
+
 static inline int host_bridge_reinit_from_ahb(struct ahb *ahb)
 {
 	return ahb->drv->reinit ? ahb->drv->reinit(ahb) : 0;

--- a/src/host.h
+++ b/src/host.h
@@ -16,6 +16,9 @@ int host_init(struct host *ctx, int argc, char *argv[]);
 void host_destroy(struct host *ctx);
 
 struct ahb *host_get_ahb(struct host *ctx);
-int host_bridge_reinit_from_ahb(struct host *ctx, struct ahb *ahb);
+static inline int host_bridge_reinit_from_ahb(struct ahb *ahb)
+{
+	return ahb->drv->reinit ? ahb->drv->reinit(ahb) : 0;
+}
 
 #endif

--- a/src/soc/wdt.c
+++ b/src/soc/wdt.c
@@ -12,6 +12,8 @@
 
 /* Registers */
 #define WDT_RELOAD	        0x04
+#define WDT_RESTART	        0x08
+#define   WDT_RESTART_MAGIC     0x4755
 #define WDT_CTRL	        0x0c
 #define   WDT_CTRL_ALT_BOOT     (1 << 7)
 #define   WDT_CTRL_RESET_SOC    (0b00 << 5)
@@ -141,6 +143,10 @@ int64_t wdt_perform_reset(struct wdt *ctx)
         return wait;
 
     rc = wdt_writel(ctx, WDT_RELOAD, wait);
+    if (rc < 0)
+        return rc;
+
+    rc = wdt_writel(ctx, WDT_RESTART, WDT_RESTART_MAGIC);
     if (rc < 0)
         return rc;
 

--- a/src/soc/wdt.c
+++ b/src/soc/wdt.c
@@ -13,8 +13,7 @@
 /* Registers */
 #define WDT_RELOAD	        0x04
 #define WDT_CTRL	        0x0c
-#define   WDT_CTRL_BOOT_1       (0 << 7)
-#define   WDT_CTRL_BOOT_2       (1 << 7)
+#define   WDT_CTRL_ALT_BOOT     (1 << 7)
 #define   WDT_CTRL_RESET_SOC    (0b00 << 5)
 #define   WDT_CTRL_RESET_SYS    (0b01 << 5)
 #define   WDT_CTRL_RESET_CPU    (0b10 << 5)
@@ -149,6 +148,7 @@ int64_t wdt_perform_reset(struct wdt *ctx)
         return rc;
 
     mode |= WDT_CTRL_RESET_SOC | WDT_CTRL_SYS_RESET | WDT_CTRL_ENABLE;
+    mode &= ~WDT_CTRL_ALT_BOOT;
 
     if ((rc = wdt_writel(ctx, WDT_CTRL, mode)) < 0)
         return rc;

--- a/src/soc/wdt.h
+++ b/src/soc/wdt.h
@@ -12,7 +12,7 @@ int wdt_prevent_reset(struct soc *soc);
 struct wdt;
 
 int wdt_init(struct wdt *ctx, struct soc *soc, const char *name);
-int64_t wdt_perform_reset(struct wdt *ctx);
+int wdt_perform_reset(struct wdt *ctx);
 void wdt_destroy(struct wdt *ctx);
 
 struct wdt *wdt_get_by_name(struct soc *soc, const char *name);


### PR DESCRIPTION
(This PR supersedes both #43 and #44, since I ended up adding some stuff to the wdt fixes that had dependencies on the changes in #43.  If you'd prefer to merge things piecemeal that's of course fine.)

These changes stem from a pair of problems I encountered:

 - On one particular board (ASRock e3c256d4i, specifically), any attempt to use the iLPC bridge would trigger an immediate host crash -- not a culvert crash or even a kernel panic, just a complete system lockup.  This motivated the first three patches (what had been in #43), which ultimately provide a way to explicitly disable certain bridges via a new command-line flag.

 - When doing a live BMC firmware reflash from the host, I've occasionally ended up with a corrupted firmware image that refused to boot.  I'm pretty certain this was caused by a delay in the wdt-based reset arriving after completing the flash write sequence, which allowed the in-memory firmware to continue running for a time, during which it issued flash erases and/or writes before the reset kicked in.  In debugging this I encountered a few problems:

   - When starting the wdt to initiate a reset, we weren't using the correct register-write sequence, leading to the wdt counting down from whatever value had previously been left in it, which on my systems was usually quite a bit longer than the desired duration.

   - We weren't setting the boot-source bit and instead just reused whatever it had previously been set to, meaning we weren't consistently booting from the default boot source after the reset.

   - In the wdt reset sequence we were un-gating the ARM clock immediately after enabling the watchdog (well before it fired), allowing execution to continue for approximately the duration of its countdown period.

In order to address these in a reasonably structured way I've made some infrastructural changes:

 -  `enum ahb_bridge` goes away in favor of pointers to `struct bridge_driver` (which now also contains the bridge name instead of those living in a separate array of their own)

 - `struct bridge driver` gains a `.release()` operation mirroring the existing `.reinit()`, the combination of which are used to bracket lengthy blocking waits; the p2a bridge driver (which was the sole existing implementer of `.reinit()`) gains a `.release()` implementation, and the debug-UART and l2a bridge drivers gain both.