### PR TITLE
Add W25Q512JV SPI Flash

### DIFF
--- a/src/flash.c
+++ b/src/flash.c
@@ -28,6 +28,9 @@ static const struct flash_info flash_info[] = {
 	{ 0xef4019, 0x02000000, FL_ERASE_ALL | FL_ERASE_64K | FL_CAN_4B |
 				FL_ERASE_BULK,
 							"Winbond W25Q256BV"},
+	{ 0xef4020, 0x04000000, FL_ERASE_ALL | FL_ERASE_64K | FL_CAN_4B |
+				FL_ERASE_BULK,
+							"Winbond W25Q512JV"},
 	{ 0x20ba20, 0x04000000, FL_ERASE_4K  | FL_ERASE_64K | FL_CAN_4B |
                                 FL_ERASE_BULK | FL_MICRON_BUGS,
                                                           "Micron N25Qx512Ax"   },


### PR DESCRIPTION
I have a system (3 actually!) with a W25Q512JV SPI Flash and when I tried to use culvert to flash it I noticed it didn't recognize my SPI Flash. This PR has been tested successfully on one of the three systems.