### PR TITLE
Add aarch64 memory barrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The can be built for multiple architectures. It's known to run on the following:
 * x86\_64
 * powerpc64, powerpc64le
 * armv6
+* aarch64
 
 It can be built with:
 

--- a/src/mb.h
+++ b/src/mb.h
@@ -10,6 +10,8 @@
 #elif defined(__x86_64__)
 #include "x86.h"
 #define iob() mfence()
+#elif defined(__aarch64__)
+#define iob() asm volatile("dsb osh" ::: "memory")
 #elif defined(__arm__)
 /*
  * HACK: Assumes we're running remotely or on the AST itself. If ARM is


### PR DESCRIPTION
This fixes the build process on aarch64 hosts and
makes them useable with culvert. Tested with P2A
and UART debug bridges.