### PR TITLE
cmd: {read,write}: Enable bounded access to RAM

### DIFF
--- a/src/ahb.c
+++ b/src/ahb.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -16,7 +17,7 @@
 
 ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, ssize_t len, int outfd)
 {
-    ssize_t ingress, egress, remaining;
+    ssize_t ingress, egress;
     void *chunk, *cursor;
     int rc = 0;
 
@@ -27,15 +28,16 @@ ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, ssize_t len, int outfd)
     if (!chunk)
         return -errno;
 
-    remaining = len;
     do {
-        ingress = remaining > AHB_CHUNK ? AHB_CHUNK : remaining;
+        ingress = (len > AHB_CHUNK || len == -1) ? AHB_CHUNK : len;
 
         ingress = ahb_read(ctx, phys, chunk, ingress);
-        if (ingress < 0) { rc = ingress; goto done; }
+        if (ingress < 0) { rc = -EIO; goto done; }
 
         phys += ingress;
-        remaining -= ingress;
+        if (len > 0) {
+            len -= ingress;
+        }
 
         cursor = chunk;
         while (ingress) {
@@ -47,7 +49,7 @@ ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, ssize_t len, int outfd)
         }
 
         fprintf(stderr, ".");
-    } while (remaining);
+    } while (!!len);
 
 done:
     fprintf(stderr, "\n");
@@ -56,7 +58,7 @@ done:
     return rc;
 }
 
-ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, int infd)
+ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, ssize_t len, int infd)
 {
     ssize_t ingress, egress;
     void *chunk;
@@ -64,15 +66,18 @@ ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, int infd)
 
     chunk = malloc(AHB_CHUNK);
     if (!chunk)
-        return -errno;
+        return -1;
 
-    while ((ingress = read(infd, chunk, AHB_CHUNK))) {
+    while ((ingress = read(infd, chunk, (len > AHB_CHUNK || len == -1) ? AHB_CHUNK : len))) {
         if (ingress < 0) { rc = -errno; goto done; }
 
         egress = ahb_write(ctx, phys, chunk, ingress);
-        if (egress < 0) { rc = egress; goto done; }
+        if (egress < 0) { rc = -EIO; goto done; }
 
         phys += ingress;
+        if (len > 0) {
+            len -= ingress;
+        }
 
         fprintf(stderr, ".");
     }

--- a/src/ahb.c
+++ b/src/ahb.c
@@ -14,7 +14,7 @@
 
 #define AHB_CHUNK (1 << 20)
 
-ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, size_t len, int outfd)
+ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, ssize_t len, int outfd)
 {
     ssize_t ingress, egress, remaining;
     void *chunk, *cursor;
@@ -56,7 +56,7 @@ done:
     return rc;
 }
 
-ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, int infd)
+ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, int infd)
 {
     ssize_t ingress, egress;
     void *chunk;

--- a/src/ahb.h
+++ b/src/ahb.h
@@ -72,8 +72,8 @@ static inline int ahb_writel(struct ahb *ctx, uint32_t phys, uint32_t val)
 }
 
 
-ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, size_t len, int outfd);
-ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, int infd);
+ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, ssize_t len, int outfd);
+ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, int infd);
 
 int ahb_release_bridge(struct ahb *ctx);
 int ahb_reinit_bridge(struct ahb *ctx);

--- a/src/ahb.h
+++ b/src/ahb.h
@@ -73,7 +73,7 @@ static inline int ahb_writel(struct ahb *ctx, uint32_t phys, uint32_t val)
 
 
 ssize_t ahb_siphon_out(struct ahb *ctx, uint32_t phys, ssize_t len, int outfd);
-ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, int infd);
+ssize_t ahb_siphon_in(struct ahb *ctx, uint32_t phys, ssize_t len, int infd);
 
 int ahb_release_bridge(struct ahb *ctx);
 int ahb_reinit_bridge(struct ahb *ctx);

--- a/src/ast.c
+++ b/src/ast.c
@@ -76,7 +76,7 @@ int ast_ahb_access(const char *name __unused, int argc, char *argv[],
                 exit(EXIT_FAILURE);
             }
         } else {
-            if ((rc = ahb_siphon_in(ahb, address, STDIN_FILENO))) {
+            if ((rc = ahb_siphon_in(ahb, address, -1, STDIN_FILENO))) {
                 errno = -rc;
                 perror("ahb_writel");
                 exit(EXIT_FAILURE);

--- a/src/ast.c
+++ b/src/ast.c
@@ -52,7 +52,7 @@ int ast_ahb_access(const char *name __unused, int argc, char *argv[],
         }
 
         if (len > 4) {
-            if ((rc = ahb_siphon_in(ahb, address, len, 1))) {
+            if ((rc = ahb_siphon_out(ahb, address, len, STDOUT_FILENO))) {
                 errno = -rc;
                 perror("ahb_siphon_in");
                 exit(EXIT_FAILURE);
@@ -76,7 +76,7 @@ int ast_ahb_access(const char *name __unused, int argc, char *argv[],
                 exit(EXIT_FAILURE);
             }
         } else {
-            if ((rc = ahb_siphon_out(ahb, address, 0))) {
+            if ((rc = ahb_siphon_in(ahb, address, STDIN_FILENO))) {
                 errno = -rc;
                 perror("ahb_writel");
                 exit(EXIT_FAILURE);

--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -5,11 +5,12 @@
 #include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "ahb.h"
@@ -83,9 +84,13 @@ ssize_t devmem_read(struct ahb *ahb, uint32_t phys, void *buf, size_t len)
     struct devmem *ctx = to_devmem(ahb);
     int64_t woff;
 
+    if (len > SSIZE_MAX) {
+        return -1;
+    }
+
     woff = devmem_setup_win(ctx, phys, len);
     if (woff < 0)
-        return woff;
+        return -1;
 
     mmio_memcpy(buf, ctx->win + woff, len);
 
@@ -97,9 +102,13 @@ ssize_t devmem_write(struct ahb *ahb, uint32_t phys, const void *buf, size_t len
     struct devmem *ctx = to_devmem(ahb);
     int64_t woff;
 
+    if (len > SSIZE_MAX) {
+        return -1;
+    }
+
     woff = devmem_setup_win(ctx, phys, len);
     if (woff < 0)
-        return woff;
+        return -1;
 
     mmio_memcpy(ctx->win + woff, buf, len);
 

--- a/src/bridge/ilpc.c
+++ b/src/bridge/ilpc.c
@@ -53,10 +53,10 @@ ssize_t ilpcb_read(struct ahb *ahb, uint32_t addr, void *buf, size_t len)
     size_t remaining;
     uint8_t data;
     int locked;
-    ssize_t rc;
+    int rc;
 
     if (len > SSIZE_MAX)
-        return -EINVAL;
+        return -1;
 
     rc = sio_unlock(sio);
     if (rc)
@@ -109,7 +109,7 @@ done:
         perror("sio_lock");
     }
 
-    return rc ? rc : (ssize_t)len;
+    return rc ? -1 : (ssize_t)len;
 }
 
 ssize_t ilpcb_write(struct ahb *ahb, uint32_t addr, const void *buf, size_t len)
@@ -118,10 +118,10 @@ ssize_t ilpcb_write(struct ahb *ahb, uint32_t addr, const void *buf, size_t len)
     struct sio *sio = &ctx->sio;
     size_t remaining;
     int locked;
-    ssize_t rc;
+    int rc;
 
     if (len > SSIZE_MAX)
-        return -EINVAL;
+        return -1;
 
     rc = sio_unlock(sio);
     if (rc)
@@ -173,7 +173,7 @@ done:
         perror("sio_lock");
     }
 
-    return rc ? rc : (ssize_t)len;
+    return rc ? -1 : (ssize_t)len;
 }
 
 /* Little-endian */

--- a/src/bridge/l2a.c
+++ b/src/bridge/l2a.c
@@ -9,6 +9,7 @@
 #include "ccan/container_of/container_of.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -73,16 +74,20 @@ ssize_t l2ab_read(struct ahb *ahb, uint32_t phys, void *buf, size_t len)
     ssize_t ingress;
     int64_t offset;
 
+    if (len > SSIZE_MAX) {
+        return -1;
+    }
+
     do {
         ingress = remaining > L2AB_WINDOW_SIZE ? L2AB_WINDOW_SIZE : remaining;
 
         offset = l2ab_map(ctx, phys, ingress);
         if (offset < 0)
-            return offset;
+            return -1;
 
         ingress = lpc_read(&ctx->fw, offset, buf, ingress);
         if (ingress < 0)
-            return ingress;
+            return -1;
 
         phys += ingress;
         buf += ingress;
@@ -99,16 +104,20 @@ ssize_t l2ab_write(struct ahb *ahb, uint32_t phys, const void *buf, size_t len)
     ssize_t egress;
     int64_t offset;
 
+    if (len > SSIZE_MAX) {
+        return -1;
+    }
+
     do {
         egress = remaining > L2AB_WINDOW_SIZE ? L2AB_WINDOW_SIZE : remaining;
 
         offset = l2ab_map(ctx, phys, egress);
         if (offset < 0)
-            return offset;
+            return -1;
 
         egress = lpc_write(&ctx->fw, offset, buf, egress);
         if (egress < 0)
-            return egress;
+            return -1;
 
         phys += egress;
         buf += egress;

--- a/src/bridge/p2a.c
+++ b/src/bridge/p2a.c
@@ -18,6 +18,7 @@
 #include <endian.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -117,12 +118,16 @@ ssize_t p2ab_read(struct ahb *ahb, uint32_t phys, void *buf, size_t len)
     size_t ingress;
     int64_t rc;
 
+    if (len > SSIZE_MAX) {
+        return -1;
+    }
+
     do {
         ingress = remaining > P2AB_WINDOW_LEN ? P2AB_WINDOW_LEN : remaining;
 
         rc = p2ab_map(ctx, phys, ingress);
         if (rc < 0)
-            return rc;
+            return -1;
 
         mmio_memcpy(buf, (ctx->mmio + P2AB_WINDOW_BASE + rc), ingress);
         phys += ingress;
@@ -140,12 +145,16 @@ ssize_t p2ab_write(struct ahb *ahb, uint32_t phys, const void *buf, size_t len)
     size_t egress;
     int64_t rc;
 
+    if (len > SSIZE_MAX) {
+        return -1;
+    }
+
     do {
         egress = remaining > P2AB_WINDOW_LEN ? P2AB_WINDOW_LEN : remaining;
 
         rc = p2ab_map(ctx, phys, egress);
         if (rc < 0)
-            return rc;
+            return -1;
 
         mmio_memcpy((ctx->mmio + P2AB_WINDOW_BASE + rc), buf, egress);
         phys += egress;

--- a/src/cmd/coprocessor.c
+++ b/src/cmd/coprocessor.c
@@ -160,7 +160,7 @@ static int cmd_coprocessor_run(const char *name __unused, int argc, char *argv[]
 
     /* 3. */
     /* TODO: Verify firmware fits inside specified region, somehow? */
-    if ((src = soc_siphon_out(soc, mem_base, STDIN_FILENO)) < 0) {
+    if ((src = soc_siphon_in(soc, mem_base, STDIN_FILENO)) < 0) {
         loge("Failed to load coprocessor firmware to provided region: %d\n", src);
         rc = EXIT_FAILURE;
         goto cleanup_scu;

--- a/src/cmd/coprocessor.c
+++ b/src/cmd/coprocessor.c
@@ -159,8 +159,7 @@ static int cmd_coprocessor_run(const char *name __unused, int argc, char *argv[]
     }
 
     /* 3. */
-    /* TODO: Verify firmware fits inside specified region, somehow? */
-    if ((src = soc_siphon_in(soc, mem_base, STDIN_FILENO)) < 0) {
+    if ((src = soc_siphon_in(soc, mem_base, mem_size, STDIN_FILENO)) < 0) {
         loge("Failed to load coprocessor firmware to provided region: %d\n", src);
         rc = EXIT_FAILURE;
         goto cleanup_scu;

--- a/src/cmd/read.c
+++ b/src/cmd/read.c
@@ -19,8 +19,11 @@
 #include <string.h>
 #include <unistd.h>
 
-static int cmd_dump_firmware(struct soc *soc)
+static int cmd_read_firmware(int argc, char *argv[])
 {
+    struct host _host, *host = &_host;
+    struct soc _soc, *soc = &_soc;
+    struct ahb *ahb;
     struct soc_region flash;
     struct flash_chip *chip;
     struct sfc *sfc;
@@ -28,15 +31,30 @@ static int cmd_dump_firmware(struct soc *soc)
     int cleanup;
     int rc;
 
+    if ((rc = host_init(host, argc, argv)) < 0) {
+        loge("Failed to initialise host interfaces: %d\n", rc);
+        return rc;
+    }
+
+    if (!(ahb = host_get_ahb(host))) {
+        loge("Failed to acquire AHB interface, exiting\n");
+        rc = -ENODEV;
+        goto cleanup_host;
+    }
+
+    if ((rc = soc_probe(soc, ahb)) < 0)
+        goto cleanup_host;
+
     logi("Initialising flash controller\n");
     if (!(sfc = sfc_get_by_name(soc, "fmc"))) {
         loge("Failed to acquire SPI controller\n");
-        return -ENODEV;
+        rc = -ENODEV;
+        goto cleanup_soc;
     }
 
     logi("Initialising flash chip\n");
     if ((rc = flash_init(sfc, &chip))) {
-        return rc;
+        goto cleanup_soc;
     }
 
     logi("Write-protecting all chip-selects\n");
@@ -47,7 +65,7 @@ static int cmd_dump_firmware(struct soc *soc)
         goto cleanup_chip;
 
     logi("Exfiltrating BMC flash to stdout\n\n");
-    rc = soc_siphon_out(soc, flash.start, chip->info.size, STDOUT_FILENO);
+    rc = soc_siphon_out(soc, flash.start, chip->info.size, 1);
     if (rc) { errno = -rc; perror("soc_siphon_in"); }
 
     if ((cleanup = sfc_write_protect_restore(sfc, wp)) < 0) {
@@ -58,82 +76,141 @@ static int cmd_dump_firmware(struct soc *soc)
 cleanup_chip:
     flash_destroy(chip);
 
-    return rc;
-}
+cleanup_soc:
+    soc_destroy(soc);
 
-static int cmd_dump_ram(struct soc *soc)
-{
-    struct soc_region dram, vram;
-    struct sdmc *sdmc;
-    int rc;
-
-    if (!(sdmc = sdmc_get(soc))) {
-        return -ENODEV;
-    }
-
-    if ((rc = sdmc_get_dram(sdmc, &dram))) {
-        return rc;
-    }
-
-    if ((rc = sdmc_get_vram(sdmc, &vram))) {
-        return rc;
-    }
-
-    logi("%dMiB DRAM with %dMiB VRAM; dumping %dMiB (0x%x-0x%08x)\n",
-         dram.length >> 20, vram.length >> 20,
-         (dram.length - vram.length) >> 20, dram.start, vram.start - 1);
-
-    rc = soc_siphon_out(soc, dram.start, dram.length - vram.length, STDOUT_FILENO);
-    if (rc) {
-        errno = -rc;
-        perror("soc_siphon_in");
-    }
+cleanup_host:
+    host_destroy(host);
 
     return rc;
 }
 
-int cmd_read(const char *name __unused, int argc, char *argv[])
+static int cmd_read_ram(int argc, char *argv[])
 {
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
+    struct soc_region dram, vram;
+    unsigned long start, length;
+    struct sdmc *sdmc;
     struct ahb *ahb;
+    char *endp;
     int rc;
 
-    if (argc < 1) {
-        loge("Not enough arguments for read command\n");
-        exit(EXIT_FAILURE);
+    /* FIXME: doesn't handle bridge argument parsing */
+    if (argc >= 2) {
+        errno = 0;
+        start = strtoul(argv[0], &endp, 0);
+        if (start == ULONG_MAX && errno) {
+            loge("Failed to parse RAM region start address '%s': %s\n", argv[0], strerror(errno));
+            return -errno;
+#if ULONG_MAX > UINT32_MAX
+        } else if (start > UINT32_MAX) {
+            loge("RAM region start address '%s' exceeds address space\n", argv[0]);
+            return -EINVAL;
+#endif
+        }
+        argc--;
+        argv++;
+
+        errno = 0;
+        length = strtoul(argv[0], &endp, 0);
+        if (length == ULONG_MAX && errno) {
+            loge("Failed to parse RAM region length '%s': %s\n", argv[0], strerror(errno));
+            return -errno;
+#if ULONG_MAX > UINT32_MAX
+        } else if (length > UINT32_MAX) {
+            loge("RAM region length '%s' exceeds address space\n", argv[0]);
+            return -EINVAL;
+#endif
+        }
+        argc--;
+        argv++;
+    } else {
+        start = 0;
+        length = 0;
     }
 
-    if ((rc = host_init(host, argc - 1, argv + 1)) < 0) {
+    if (UINT32_MAX - length < start) {
+        return -EINVAL;
+    }
+
+    if ((rc = host_init(host, argc, argv)) < 0) {
         loge("Failed to initialise host interfaces: %d\n", rc);
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     if (!(ahb = host_get_ahb(host))) {
         loge("Failed to acquire AHB interface, exiting\n");
-        rc = EXIT_FAILURE;
+        rc = -ENODEV;
         goto cleanup_host;
     }
 
     if ((rc = soc_probe(soc, ahb)) < 0)
         goto cleanup_host;
 
-    if (!strcmp("firmware", argv[0]))
-        rc = cmd_dump_firmware(soc);
-    else if (!strcmp("ram", argv[0]))
-        rc = cmd_dump_ram(soc);
-    else {
-        loge("Unsupported read type '%s'", argv[0]);
-        rc = -EINVAL;
+
+    if (!(sdmc = sdmc_get(soc))) {
+        rc = -ENODEV;
+        goto cleanup_soc;
     }
 
+    if ((rc = sdmc_get_dram(sdmc, &dram))) {
+        goto cleanup_soc;
+    }
+
+    if (start && length) {
+        if (start < dram.start || (start + length) > (dram.start + dram.length)) {
+            rc = -EINVAL;
+            goto cleanup_soc;
+        }
+
+        logi("Dumping %" PRId32 "MiB (%#.8" PRIx32 "-%#.8" PRIx32 ")",
+             length >> 20, start, start + length - 1);
+    } else {
+        if ((rc = sdmc_get_vram(sdmc, &vram))) {
+            goto cleanup_soc;
+        }
+
+        start = dram.start;
+        length = dram.length - vram.length;
+
+        logi("%dMiB DRAM with %dMiB VRAM; dumping %dMiB (0x%x-0x%08x)\n",
+             dram.length >> 20, vram.length >> 20,
+             (dram.length - vram.length) >> 20, dram.start, vram.start - 1);
+    }
+
+    rc = soc_siphon_out(soc, start, length, STDOUT_FILENO);
+    if (rc) {
+        errno = -rc;
+        perror("soc_siphon_in");
+    }
+
+cleanup_soc:
     soc_destroy(soc);
 
 cleanup_host:
     host_destroy(host);
 
-    if (rc < 0)
-        exit(EXIT_FAILURE);
+    return rc;
+}
 
-    return 0;
+int cmd_read(const char *name __unused, int argc, char *argv[])
+{
+    int rc;
+
+    if (argc < 1) {
+        loge("Not enough arguments for read command\n");
+        return EXIT_FAILURE;
+    }
+
+    if (!strcmp("firmware", argv[0])) {
+        rc = cmd_read_firmware(argc - 1, argv + 1);
+    } else if (!strcmp("ram", argv[0])) {
+        rc = cmd_read_ram(argc - 1, argv + 1);
+    } else {
+        loge("Unsupported read type '%s'", argv[0]);
+        rc = -EINVAL;
+    }
+
+    return rc < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/src/cmd/read.c
+++ b/src/cmd/read.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 static int cmd_dump_firmware(struct soc *soc)
 {
@@ -46,7 +47,7 @@ static int cmd_dump_firmware(struct soc *soc)
         goto cleanup_chip;
 
     logi("Exfiltrating BMC flash to stdout\n\n");
-    rc = soc_siphon_in(soc, flash.start, chip->info.size, 1);
+    rc = soc_siphon_out(soc, flash.start, chip->info.size, STDOUT_FILENO);
     if (rc) { errno = -rc; perror("soc_siphon_in"); }
 
     if ((cleanup = sfc_write_protect_restore(sfc, wp)) < 0) {
@@ -82,7 +83,7 @@ static int cmd_dump_ram(struct soc *soc)
          dram.length >> 20, vram.length >> 20,
          (dram.length - vram.length) >> 20, dram.start, vram.start - 1);
 
-    rc = soc_siphon_in(soc, dram.start, dram.length - vram.length, 1);
+    rc = soc_siphon_out(soc, dram.start, dram.length - vram.length, STDOUT_FILENO);
     if (rc) {
         errno = -rc;
         perror("soc_siphon_in");

--- a/src/cmd/write.c
+++ b/src/cmd/write.c
@@ -8,6 +8,7 @@
 #include "log.h"
 #include "priv.h"
 #include "soc/clk.h"
+#include "soc/sdmc.h"
 #include "soc/sfc.h"
 #include "soc/uart/vuart.h"
 #include "soc/wdt.h"
@@ -21,13 +22,13 @@
 
 #define SFC_FLASH_WIN (64 << 10)
 
-int cmd_write(const char *name __unused, int argc, char *argv[])
+static int cmd_write_firmware(int argc, char *argv[])
 {
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
+    struct ahb *ahb;
     struct flash_chip *chip;
     struct vuart *vuart;
-    struct ahb *ahb;
     struct clk *clk;
     ssize_t ingress;
     struct sfc *sfc;
@@ -35,63 +36,31 @@ int cmd_write(const char *name __unused, int argc, char *argv[])
     uint32_t phys;
     char *buf;
 
-    if (argc < 1) {
-        loge("Not enough arguments for write command\n");
-        exit(EXIT_FAILURE);
-    }
-
-    if (strcmp("firmware", argv[0])) {
-        loge("Unsupported write type '%s'\n", argv[0]);
-        return -EINVAL;
-    }
-
-    /* Do option parsing for the "firmware" write type */
-    while (1) {
-        int option_index = 0;
-        int c;
-
-        static struct option long_options[] = {
-            { "live", no_argument, NULL, 'l' },
-            { },
-        };
-
-        c = getopt_long(argc, argv, "l", long_options, &option_index);
-        if (c == -1)
-            break;
-
-        switch (c) {
-            case 'l':
-                /* no-op flag retained for backwards compatibility */
-                break;
-            case '?':
-                exit(EXIT_FAILURE);
-        }
-    }
-
-    if ((rc = host_init(host, argc - optind, argv + optind)) < 0) {
+    if ((rc = host_init(host, argc, argv)) < 0) {
         loge("Failed to initialise host interfaces: %d\n", rc);
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     if (!(ahb = host_get_ahb(host))) {
         loge("Failed to acquire AHB interface, exiting\n");
-        rc = EXIT_FAILURE;
+        rc = -ENODEV;
         goto cleanup_host;
     }
 
     if ((rc = soc_probe(soc, ahb)) < 0) {
-        errno = -rc;
-        perror("soc_probe");
+        loge("Failed to probe SoC: %d\n", rc);
         goto cleanup_host;
     }
 
     if (!(clk = clk_get(soc))) {
         loge("Failed to acquire clock controller, exiting\n");
+        rc = -ENODEV;
         goto cleanup_soc;
     }
 
     if (!(vuart = vuart_get_by_name(soc, "vuart"))) {
         loge("Failed to acquire VUART controller, exiting\n");
+        rc = -ENODEV;
         goto cleanup_soc;
     }
 
@@ -114,6 +83,7 @@ int cmd_write(const char *name __unused, int argc, char *argv[])
     logi("Initialising flash subsystem\n");
     if (!(sfc = sfc_get_by_name(soc, "fmc"))) {
         loge("Failed to acquire SPI flash controller, exiting\n");
+        rc = -ENODEV;
         goto cleanup_state;
     }
 
@@ -123,8 +93,10 @@ int cmd_write(const char *name __unused, int argc, char *argv[])
 
     /* FIXME: Make this common with the sfc write implementation */
     buf = malloc(SFC_FLASH_WIN);
-    if (!buf)
+    if (!buf) {
+        rc = -ENOMEM;
         goto cleanup_flash;
+    }
 
     logi("Writing firmware image\n");
     phys = 0;
@@ -167,12 +139,13 @@ cleanup_state:
             logi("Performing SoC reset\n");
             if (!(wdt = wdt_get_by_name(soc, "wdt2"))) {
                 loge("Failed to acquire wdt2 controller, exiting\n");
-                goto cleanup_soc;
+                return -ENODEV;
             }
 
             rc = wdt_perform_reset(wdt);
-            if (rc < 0)
-                goto cleanup_soc;
+            if (rc < 0) {
+                return rc;
+            }
         }
     } else {
         logi("Deconfiguring VUART host Tx discard\n");
@@ -193,6 +166,161 @@ cleanup_soc:
 
 cleanup_host:
     host_destroy(host);
+
+    return rc;
+}
+
+static int cmd_write_ram(int argc, char *argv[])
+{
+    struct host _host, *host = &_host;
+    struct soc _soc, *soc = &_soc;
+    unsigned long start, length;
+    struct soc_region dram;
+    struct sdmc *sdmc;
+    struct ahb *ahb;
+    int rc;
+    char *endp;
+
+    /* FIXME: doesn't handle bridge argument parsing */
+    if (argc < 3) {
+        loge("Not enough arguments for `write ram` command\n");
+        return -EINVAL;
+    }
+
+    if (strcmp("ram", argv[0])) {
+        loge("Expected 'ram' command, found '%s'\n", argv[0]);
+        return -EINVAL;
+    }
+
+    argc--;
+    argv++;
+
+    errno = 0;
+    start = strtoul(argv[0], &endp, 0);
+    if (start == ULONG_MAX && errno) {
+        loge("Failed to parse RAM region start address '%s': %s\n", argv[0], strerror(errno));
+        return -errno;
+#if ULONG_MAX > UINT32_MAX
+    } else if (start > UINT32_MAX) {
+        loge("RAM region start address '%s' exceeds address space\n", argv[0]);
+        return -EINVAL;
+#endif
+    }
+    argc--;
+    argv++;
+
+    errno = 0;
+    length = strtoul(argv[0], &endp, 0);
+    if (length == ULONG_MAX && errno) {
+        loge("Failed to parse RAM region length '%s': %s\n", argv[0], strerror(errno));
+        return -errno;
+#if ULONG_MAX > UINT32_MAX
+    } else if (length > UINT32_MAX) {
+        loge("RAM region length '%s' exceeds address space\n", argv[0]);
+        return -EINVAL;
+#endif
+    }
+    argc--;
+    argv++;
+
+    if ((rc = host_init(host, argc, argv)) < 0) {
+        loge("Failed to initialise host interfaces: %d\n", rc);
+        return rc;
+    }
+
+    if (!(ahb = host_get_ahb(host))) {
+        loge("Failed to acquire AHB interface, exiting\n");
+        rc = EXIT_FAILURE;
+        goto cleanup_host;
+    }
+
+    if ((rc = soc_probe(soc, ahb)) < 0) {
+        loge("Failed to probe SoC: %d\n", rc);
+        goto cleanup_host;
+    }
+
+    if (!(sdmc = sdmc_get(soc))) {
+        loge("Failed to acquire SDRAM memory controller\n");
+        rc = -ENODEV;
+        goto cleanup_soc;
+    }
+
+    if ((rc = sdmc_get_dram(sdmc, &dram))) {
+        loge("Failed to locate DRAM: %d\n", rc);
+        goto cleanup_soc;
+    }
+
+    if (((start + length) & UINT32_MAX) < start) {
+        loge("Invalid RAM region provided for write\n");
+        rc = -EINVAL;
+        goto cleanup_soc;
+    }
+
+    if (start < dram.start || (start + length) > (dram.start + dram.length)) {
+        loge("Ill-formed RAM region provided for write\n");
+        rc = -EINVAL;
+        goto cleanup_soc;
+    }
+
+#if UINT32_MAX > SSIZE_MAX
+    if (SSIZE_MAX < length) {
+        return -EINVAL;
+    }
+#endif
+
+    if ((rc = soc_siphon_in(soc, start, length, STDIN_FILENO))) {
+        loge("Failed to write to provided memory region: %d\n", rc);
+    }
+
+cleanup_soc:
+    soc_destroy(soc);
+
+cleanup_host:
+    host_destroy(host);
+
+    return rc;
+}
+
+int cmd_write(const char *name __unused, int argc, char *argv[])
+{
+    int rc;
+
+    if (argc < 1) {
+        loge("Not enough arguments for write command\n");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do option parsing for the "firmware" write type */
+    while (1) {
+        int option_index = 0;
+        int c;
+
+        static struct option long_options[] = {
+            { "live", no_argument, NULL, 'l' },
+            { },
+        };
+
+        c = getopt_long(argc, argv, "l", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+            case 'l':
+                /* no-op flag retained for backwards compatibility */
+                break;
+            case '?':
+                return -EINVAL;
+        }
+    }
+
+    if (!strcmp("firmware", argv[optind])) {
+        rc = cmd_write_firmware(argc - optind, &argv[optind]);
+    } else if (!strcmp("ram", argv[optind])) {
+        rc = cmd_write_ram(argc - optind, &argv[optind]);
+    } else {
+        loge("Unsupported write type '%s'\n", argv[optind]);
+        rc = -EINVAL;
+    }
 
     return rc;
 }

--- a/src/culvert.c
+++ b/src/culvert.c
@@ -168,6 +168,7 @@ int main(int argc, char *argv[])
     while (cmd->fn) {
         if (!strcmp(cmd->name, argv[optind])) {
             int offset = optind;
+            int rc;
 
             /* probe uses getopt, but for subcommands not using getopt */
             if (strcmp("probe", argv[optind])) {
@@ -175,7 +176,8 @@ int main(int argc, char *argv[])
             }
             optind = 1;
 
-            return cmd->fn(program_invocation_short_name, argc - offset, argv + offset);
+            rc = cmd->fn(program_invocation_short_name, argc - offset, argv + offset);
+            exit(rc ? EXIT_FAILURE : EXIT_SUCCESS);
         }
 
         cmd++;

--- a/src/culvert.c
+++ b/src/culvert.c
@@ -56,8 +56,9 @@ static void print_help(const char *name)
     printf("%s devmem write ADDRESS VALUE\n", name);
     printf("%s console HOST_UART BMC_UART BAUD USER PASSWORD\n", name);
     printf("%s read firmware [INTERFACE [IP PORT USERNAME PASSWORD]]\n", name);
-    printf("%s read ram [INTERFACE [IP PORT USERNAME PASSWORD]]\n", name);
+    printf("%s read ram ADDRESS LENGTH [INTERFACE [IP PORT USERNAME PASSWORD]]\n", name);
     printf("%s write firmware [INTERFACE [IP PORT USERNAME PASSWORD]]\n", name);
+    printf("%s write ram ADDRESS LENGTH [INTERFACE [IP PORT USERNAME PASSWORD]]\n", name);
     printf("%s replace ram MATCH REPLACE\n", name);
     printf("%s reset TYPE WDT [INTERFACE [IP PORT USERNAME PASSWORD]]\n", name);
     printf("%s jtag [INTERFACE [IP PORT USERNAME PASSWORD]]\n", name);
@@ -171,7 +172,7 @@ int main(int argc, char *argv[])
             int rc;
 
             /* probe uses getopt, but for subcommands not using getopt */
-            if (strcmp("probe", argv[optind])) {
+            if (!(!strcmp("probe", argv[optind]) || !strcmp("write", argv[optind]))) {
                 offset += 1;
             }
             optind = 1;

--- a/src/soc.h
+++ b/src/soc.h
@@ -64,15 +64,15 @@ static inline int soc_writel(struct soc *ctx, uint32_t phys, uint32_t val)
 }
 
 static inline ssize_t
-soc_siphon_in(struct soc *ctx, uint32_t phys, size_t len, int outfd)
+soc_siphon_out(struct soc *ctx, uint32_t phys, size_t len, int outfd)
 {
-	return ahb_siphon_in(ctx->ahb, phys, len, outfd);
+	return ahb_siphon_out(ctx->ahb, phys, len, outfd);
 }
 
 static inline ssize_t
-soc_siphon_out(struct soc *ctx, uint32_t phys, int infd)
+soc_siphon_in(struct soc *ctx, uint32_t phys, int infd)
 {
-	return ahb_siphon_out(ctx->ahb, phys, infd);
+	return ahb_siphon_in(ctx->ahb, phys, infd);
 }
 
 struct soc_device_node {

--- a/src/soc.h
+++ b/src/soc.h
@@ -70,9 +70,9 @@ soc_siphon_out(struct soc *ctx, uint32_t phys, size_t len, int outfd)
 }
 
 static inline ssize_t
-soc_siphon_in(struct soc *ctx, uint32_t phys, int infd)
+soc_siphon_in(struct soc *ctx, uint32_t phys, ssize_t length, int infd)
 {
-	return ahb_siphon_in(ctx->ahb, phys, infd);
+	return ahb_siphon_in(ctx->ahb, phys, length, infd);
 }
 
 struct soc_device_node {

--- a/src/soc/trace.c
+++ b/src/soc/trace.c
@@ -237,7 +237,7 @@ int trace_dump(struct trace *ctx, int outfd)
 
         logd("Ring buffer has wrapped, dumping trace buffer from write pointer at 0x%" PRIx32 " for %zu\n",
              buf, len);
-        if ((rc = soc_siphon_in(ctx->soc, buf, len, outfd)))
+        if ((rc = soc_siphon_out(ctx->soc, buf, len, outfd)))
             return rc;
     }
 
@@ -245,7 +245,7 @@ int trace_dump(struct trace *ctx, int outfd)
 
     logd("Dumping from trace buffer at 0x%" PRIx32 " for %zu\n", base, len);
 
-    if ((rc = soc_siphon_in(ctx->soc, base, len, outfd)))
+    if ((rc = soc_siphon_out(ctx->soc, base, len, outfd)))
         return rc;
 
     return rc;


### PR DESCRIPTION
The current motivation is to allow arbitrary writes to RAM for pre-loading data to be consumed by the secondary processor firmware.