### PR TITLE
bridge: debug: Always try to exit debug first

### DIFF
--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -46,6 +46,18 @@ int debug_enter(struct debug *ctx)
 
     logi("Entering debug mode\n");
 
+    // Blindly try to exit debug mode first
+    rc = console_set_baud(ctx->console, 115200);
+    if (rc < 0)
+        return rc;
+
+    // Escape character should cancel previous commands
+    // q will exit debug mode
+    rc = prompt_write(&ctx->prompt, "\x1Bq\r\n\x1Bq\r\n", strlen("\x1Bq\r\n\x1Bq\r\n"));
+    if (rc < 0)
+        return rc;
+
+    // Enter debug mode
     rc = console_set_baud(ctx->console, 1200);
     if (rc < 0)
         return rc;


### PR DESCRIPTION
The Debug UART inside the BMC can be brought into a stuck state by sending a lot of requests quickly or after sending a broken command.
Sending 2 exit commands at 115200 baud before trying to enter debug mode again seems to mitigate this issue.

Sidenote: I wonder how that Debug UART is actually realized inside the ASPEED. I'm almost guessing it's a little 8051 core or something similar, which might crash here. I would expect to see a little bit different behaviour from a hardware state machine. 
