### PR TITLE
meson: make the git dependency optional

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -55,8 +55,7 @@ subdir('devicetree')
 subdir('soc')
 
 # Version
-git = find_program('git')
-version = vcs_tag(command: [git, 'describe', '--tags', '--dirty', '--always'],
+version = vcs_tag(command: ['git', 'describe', '--tags', '--dirty', '--always'],
                   fallback: meson.project_version(),
                   input: 'version.h.in',
                   output: 'version.h',


### PR DESCRIPTION
By relying on the shell to find the path to git instead of using `find_command`, this makes the dependency on git optional.

If not found it will just use the provided fallback (`meson.project_version`).