### PR TITLE
meson: drop dtc subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,10 +17,4 @@ libfdt_dep = dependency('libfdt',
 			fallback: [ 'dtc', 'libfdt_dep' ],
 			required: true)
 
-libfdt_native_dep = dependency('dtc',
-		     native: true,
-		     default_options: [ 'tools=true' ],
-		     fallback: [ 'dtc', 'libfdt_dep' ],
-		     required: true)
-
 subdir('src')


### PR DESCRIPTION
This drops the build of dtc. This was intended to build the dtc binary locally if not already present, but this causes issues for packaging of the util.

Fixes #61