### PR TITLE
github: enforce DCO with CI

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,10 @@
+name: DCO
+
+on: pull_request
+
+jobs:
+  check:
+    name: Developer Certificate of Origin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tisonkun/actions-dco@v1.1


### PR DESCRIPTION
with https://github.com/amboar/culvert/pull/64#pullrequestreview-2376947442 I figured you might want CI to check that for you.