### PR TITLE
readme: add Python3 library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ meson setup build-arm --cross-file meson/arm-linux-gnueabi-gcc.ini && meson co
 
 #### Dependencies (Debian)
 ```
-apt install build-essential flex swig bison meson device-tree-compiler libyaml-dev
+apt install build-essential flex swig bison meson device-tree-compiler libyaml-dev libpython3-dev
 ```
 
 ## Execution and Example output


### PR DESCRIPTION
libfdt (subproject) requires Python3 development headers to
compile its pylibfdt bindings.