### PR TITLE
devcontainer: add manifest and Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    flex \
+    swig \
+    bison \
+    meson \
+    device-tree-compiler \
+    libyaml-dev \
+    cmake \
+    pkg-config \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=vscode
+ARG GROUPNAME=vscode
+
+# If you are on macOS using Colima with virtiofs or 9p, you may need to update the UID/GID values to match your host system.
+# ARG USER_UID=501
+# ARG USER_GID=20
+# 
+# RUN groupmod --gid $USER_GID -o $GROUPNAME \
+#     && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
+#     && chown -R $USER_UID:$USER_GID /home/$USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+    "name": "culvert dev environment",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/python:1": {},
+        "ghcr.io/devcontainers-contrib/features/meson-asdf:2": {},
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.vscode-docker",
+                "ms-python.python",
+                "ms-vscode.cmake-tools",
+                "ms-vscode.cpptools-extension-pack",
+                "zxh404.vscode-proto3"
+            ],
+            "settings": {
+                "python.pythonPath": "/usr/local/bin/python3"
+            }
+        }
+    },
+    "postCreateCommand": "pip install meson"
+}


### PR DESCRIPTION
Devcontainer allows to develop software within a container which is isolated from the system, except for passing the workspace to the container.
This allows the development on non-Linux systems such as macOS without having to run a full-blown virtual machine, but only a small container (where the Linux layer is either remote or in a small QEMU instance via e.g. Colima).