### PR TITLE
cmd: migrate from getopt to argp

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,13 +5,17 @@ RUN apt-get update && apt-get install -y \
     flex \
     swig \
     bison \
-    meson \
+    ninja-build \
     device-tree-compiler \
     libyaml-dev \
     cmake \
     pkg-config \
+    python3 \
+    python3-pip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install meson
 
 ARG USERNAME=vscode
 ARG GROUPNAME=vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
     },
     "features": {
         "ghcr.io/devcontainers/features/python:1": {},
-        "ghcr.io/devcontainers-contrib/features/meson-asdf:2": {},
         "ghcr.io/devcontainers/features/git:1": {}
     },
     "customizations": {
@@ -22,6 +21,5 @@
                 "python.pythonPath": "/usr/local/bin/python3"
             }
         }
-    },
-    "postCreateCommand": "pip install meson"
+    }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# Visual Studio Code config
+.vscode/
+
+# Subprojects pulled via meson
+subprojects/*
+!subprojects/*.wrap
+
+# segfault core file
+*/core
+
+# Output files
 *.d
 *.o
 *.swp

--- a/README.md
+++ b/README.md
@@ -106,31 +106,44 @@ $ meson setup build-arm --cross-file meson/arm-linux-gnueabi-gcc.ini && meson co
 
 #### Dependencies (Debian)
 ```
-apt install build-essential flex swig bison meson device-tree-compiler libyaml-dev
+apt install build-essential flex swig bison meson device-tree-compiler libyaml-dev qemu-user
 ```
 
 ## Execution and Example output
 
 ```
-$ ./build/src/culvert -h
-culvert: v0.4.0-196-g34001fbe828a
-Usage:
+$ ./build/src/culvert --help
+Usage: culvert [OPTION...] <cmd> [CMD_OPTIONS]...
 
-        culvert console HOST_UART BMC_UART BAUD USER PASSWORD
-        culvert coprocessor <run ADDRESS LENGTH|stop> [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert debug <read ADDRESS|write ADDRESS VALUE> INTERFACE [IP PORT USERNAME PASSWORD]
-        culvert devmem <read ADDRESS|write ADDRESS VALUE>
-        culvert ilpc <read ADDRESS|write ADDRESS VALUE
-        culvert jtag [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert otp <read <conf|strap>|write <conf WORD BIT|strap BIT VALUE>> [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert p2a vga <read ADDRESS|write ADDRESS VALUE>
-        culvert probe [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert read <firmware|ram ADDRESS LENGTH> [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert replace ram MATCH REPLACE
-        culvert reset TYPE WDT [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert sfc fmc <erase|read|write> ADDRESS LENGTH [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert trace ADDRESS WIDTH MODE [INTERFACE [IP PORT USERNAME PASSWORD]]
-        culvert write <firmware|ram ADDRESS LENGTH> [INTERFACE [IP PORT USERNAME PASSWORD]]
+Culvert — A Test and Debug Tool for BMC AHB Interfaces
+
+  -l, --list-bridges         List available bridge drivers
+  -q, --quiet                Don't produce any output
+  -s, --skip-bridge=BRIDGE   Skip BRIDGE driver
+  -v, --verbose              Get verbose output
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
+  -V, --version              Print program version
+
+Mandatory or optional arguments to long options are also mandatory or optional
+for any corresponding short options.
+
+Available commands:
+  console              Start a getty on the BMC console
+  coprocessor          Do things on the coprocessors of the AST2600
+  debug                Read or write 4 bytes of data via the AHB bridge
+  devmem               Read or write data to /dev/mem
+  ilpc                 Read or write via iLPC
+  jtag                 Start a JTAG OpenOCD Bitbang server
+  otp                  Read and write the OTP configuration (AST2600-only)
+  p2a                  Read or write data via p2a devices
+  probe                Probe for any BMC
+  read                 Read data from the FMC or RAM
+  replace              Replace a portion in the memory
+  reset                Reset a component of the BMC chip
+  sfc                  Read, write or erase areas of a supported SFC
+  trace                Trace what happens on a register
+  write                Write data to the FMC or RAM
 ```
 
 ```
@@ -157,4 +170,54 @@ ilpc:   Disabled
 # echo $?
 1
 #
+```
+
+```
+# ./culvert probe --help
+Usage: culvert probe [OPTION...]
+            [-l] [-r REQUIREMENT] [via DRIVER [INTERFACE [IP PORT USERNAME
+            PASSWORD]]]
+
+Probe command
+
+  -l, --list-interfaces      List available interfaces
+  -r, --require=REQUIREMENT  Requirement to probe for
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
+  -V, --version              Print program version
+
+Mandatory or optional arguments to long options are also mandatory or optional
+for any corresponding short options.
+
+Supported requirements:
+  integrity        Require integrity
+  confidentiality  Require confidentiality
+
+Report bugs to GitHub amboar/culvert.
+
+# ./culvert probe via debug-uart /dev/ttyUSB0
+[*] Opening /dev/ttyUSB0
+[*] Entering debug mode
+xdma:   Restricted
+        BMC: Disabled
+        VGA: Enabled
+        XDMA on VGA: Enabled
+        XDMA is constrained: Yes
+p2a:    Permissive
+        BMC: Disabled
+        VGA: Enabled
+        MMIO on VGA: Enabled
+        [0x00000000 - 0x0fffffff]   Firmware: Writable
+        [0x10000000 - 0x1fffffff]     SoC IO: Writable
+        [0x20000000 - 0x2fffffff]  BMC Flash: Writable
+        [0x30000000 - 0x3fffffff] Host Flash: Writable
+        [0x40000000 - 0x5fffffff]   Reserved: Writable
+        [0x60000000 - 0x7fffffff]   LPC Host: Writable
+        [0x80000000 - 0xffffffff]       DRAM: Writable
+debug:  Permissive
+        Debug UART port: UART1
+debug:  Permissive
+        Debug UART port: UART5
+ilpc:   Disabled
+[*] Exiting debug mode
 ```

--- a/src/ast.c
+++ b/src/ast.c
@@ -21,62 +21,50 @@
 #include <string.h>
 #include <unistd.h>
 
-int ast_ahb_access(const char *name __unused, int argc, char *argv[],
-                   struct ahb *ahb)
+/**
+ * Access raw data via the AHB bridge in the memory-mapped regions.
+ *
+ * Read behaviour: If the default read width of 4 is being overwritten,
+ * then the data will be written to stdout without any modification.
+ * This may be useful for reading FMC regions.
+ *
+ * Write behaviour: If the pointer of the write value is NULL, then it
+ * will need data to be written to stdin.
+ */
+int ast_ahb_access(struct ast_ahb_args *args, struct ahb *ahb)
 {
-    uint32_t address, data;
-    bool action_read;
+    uint32_t data;
     int rc;
 
-    if (argc < 2) {
-        loge("Not enough arguments for AHB access\n");
-        exit(EXIT_FAILURE);
-    }
-
-    if (!strcmp("read", argv[0]))
-        action_read = true;
-    else if (!strcmp("write", argv[0]))
-        action_read = false;
-    else {
-        loge("Unknown action: %s\n", argv[0]);
-        exit(EXIT_FAILURE);
-    }
-
-    address = strtoul(argv[1], NULL, 0);
-
-    if (action_read) {
+    if (args->read) {
         unsigned long len = 4;
 
-        if (argc >= 3) {
-            len = strtoul(argv[2], NULL, 0);
-        }
+        if (args->read_length != NULL)
+            len = *args->read_length;
 
         if (len > 4) {
-            if ((rc = ahb_siphon_out(ahb, address, len, STDOUT_FILENO))) {
+            if ((rc = ahb_siphon_out(ahb, args->address, len, STDOUT_FILENO))) {
                 errno = -rc;
                 perror("ahb_siphon_in");
                 exit(EXIT_FAILURE);
             }
         } else {
-            if ((rc = ahb_readl(ahb, address, &data))) {
+            if ((rc = ahb_readl(ahb, args->address, &data))) {
                 errno = -rc;
                 perror("ahb_readl");
                 exit(EXIT_FAILURE);
             }
-            printf("0x%08x: 0x%08x\n", address, le32toh(data));
+            printf("0x%08x: 0x%08x\n", args->address, le32toh(data));
         }
     } else {
-        unsigned long data;
-
-        if (argc >= 3) {
-            data = strtoul(argv[2], NULL, 0);
-            if ((rc = ahb_writel(ahb, address, htole32(data)))) {
+        if (args->write_value != NULL) {
+            if ((rc = ahb_writel(ahb, args->address, htole32(*args->write_value)))) {
                 errno = -rc;
                 perror("ahb_writel");
                 exit(EXIT_FAILURE);
             }
         } else {
-            if ((rc = ahb_siphon_in(ahb, address, -1, STDIN_FILENO))) {
+            if ((rc = ahb_siphon_in(ahb, args->address, -1, STDIN_FILENO))) {
                 errno = -rc;
                 perror("ahb_writel");
                 exit(EXIT_FAILURE);

--- a/src/ast.h
+++ b/src/ast.h
@@ -6,6 +6,25 @@
 
 #include "ahb.h"
 
-int ast_ahb_access(const char *name, int argc, char *argv[], struct ahb *ahb);
+#include <stdbool.h>
+#include <stdlib.h>
+
+struct ast_ahb_args {
+    /**
+     * read_length defines the width of an address to be read and is
+     * not always required.
+     */
+    uint32_t *read_length;
+
+    /**
+     * write_value is only required for bit-wise operations like register
+     * modifications. For binary data, please consider to pipe the data to stdin.
+     */
+    uint32_t *write_value;
+    uint32_t address;
+    bool read;
+};
+
+int ast_ahb_access(struct ast_ahb_args *args, struct ahb *ahb);
 
 #endif

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -18,6 +18,9 @@ struct bridge_driver {
 	int (*reinit)(struct ahb *ahb);
 	void (*destroy)(struct ahb *ahb);
 
+	/* Whether or not an explicit device path is required (i.e. debug-uart) */
+	bool path_required;
+
 	/*
 	 * Whether or not this driver is for running culvert on the BMC itself
 	 * (i.e. devmem)

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -7,12 +7,13 @@
 #include <stdbool.h>
 
 #include "ahb.h"
+#include "connection.h"
 
 #include "ccan/autodata/autodata.h"
 
 struct bridge_driver {
 	const char *name;
-	struct ahb *(*probe)(int argc, char *argv[]);
+	struct ahb *(*probe)(struct connection_args *connection);
 	int (*release)(struct ahb *ahb);
 	int (*reinit)(struct ahb *ahb);
 	void (*destroy)(struct ahb *ahb);

--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -468,6 +468,7 @@ static struct bridge_driver debug_driver = {
     .destroy = debug_driver_destroy,
     .release = debug_driver_release,
     .reinit = debug_driver_reinit,
+    .path_required = true,
 };
 REGISTER_BRIDGE_DRIVER(debug_driver);
 

--- a/src/bridge/debug.c
+++ b/src/bridge/debug.c
@@ -44,8 +44,23 @@ int debug_enter(struct debug *ctx)
 {
     int rc;
 
+    if (ctx->force_quit) {
+        logi("Foce quit requested\n");
+        rc = console_set_baud(ctx->console, 115200);
+        if (rc < 0)
+            return rc;
+
+        // Escape character should cancel previous commands
+        // q will exit debug mode
+        rc = prompt_write(&ctx->prompt,
+                          "\x1Bq\r\n\x1Bq\r\n", strlen("\x1Bq\r\n\x1Bq\r\n"));
+        if (rc < 0)
+            return rc;
+    }
+
     logi("Entering debug mode\n");
 
+    // Enter debug mode
     rc = console_set_baud(ctx->console, 1200);
     if (rc < 0)
         return rc;

--- a/src/bridge/debug.h
+++ b/src/bridge/debug.h
@@ -18,6 +18,7 @@ struct debug {
     struct console *console;
     struct prompt prompt;
     int port;
+    int force_quit;
 };
 
 int debug_init(struct debug *ctx, ...);

--- a/src/bridge/devmem.c
+++ b/src/bridge/devmem.c
@@ -17,6 +17,7 @@
 #include "ast.h"
 #include "bridge.h"
 #include "compiler.h"
+#include "connection.h"
 #include "devmem.h"
 #include "log.h"
 #include "mb.h"
@@ -175,7 +176,7 @@ static const struct ahb_ops devmem_ahb_ops = {
     .writel = devmem_writel
 };
 
-static struct ahb *devmem_driver_probe(int argc, char *argv[]);
+static struct ahb *devmem_driver_probe(struct connection_args *connection);
 static void devmem_driver_destroy(struct ahb *ahb);
 
 static struct bridge_driver devmem_driver = {
@@ -230,15 +231,10 @@ int devmem_destroy(struct devmem *ctx)
 }
 
 static struct ahb *
-devmem_driver_probe(int argc, char *argv[] __unused)
+devmem_driver_probe(struct connection_args *connection __unused)
 {
     struct devmem *ctx;
     int rc;
-
-    // This driver doesn't require args, so if there are any we're not trying to probe it
-    if (argc > 0) {
-        return NULL;
-    }
 
     ctx = malloc(sizeof(*ctx));
     if (!ctx) {

--- a/src/bridge/ilpc.c
+++ b/src/bridge/ilpc.c
@@ -5,6 +5,7 @@
 #include "bridge.h"
 #include "bridge/ilpc.h"
 #include "compiler.h"
+#include "connection.h"
 #include "log.h"
 #include "rev.h"
 
@@ -308,7 +309,7 @@ static const struct ahb_ops ilpcb_ops = {
     .writel = ilpcb_writel
 };
 
-static struct ahb *ilpcb_driver_probe(int argc, char *argv[]);
+static struct ahb *ilpcb_driver_probe(struct connection_args *connection);
 static void ilpcb_driver_destroy(struct ahb *ahb);
 
 static struct bridge_driver ilpcb_driver = {
@@ -331,15 +332,10 @@ int ilpcb_destroy(struct ilpcb *ctx)
 }
 
 static struct ahb *
-ilpcb_driver_probe(int argc, char *argv[] __unused)
+ilpcb_driver_probe(struct connection_args *connection __unused)
 {
     struct ilpcb *ctx;
     int rc;
-
-    // This driver doesn't require args, so if there are any we're not trying to probe it
-    if (argc > 0) {
-        return NULL;
-    }
 
     ctx = malloc(sizeof(*ctx));
     if (!ctx) {

--- a/src/bridge/l2a.c
+++ b/src/bridge/l2a.c
@@ -3,6 +3,7 @@
 
 #include "bridge.h"
 #include "compiler.h"
+#include "connection.h"
 #include "l2a.h"
 #include "log.h"
 
@@ -170,7 +171,7 @@ static int l2ab_restore_hicr78(struct l2ab *ctx)
     return ilpcb_writel(ilpcb_as_ahb(ilpcb), LPC_HICR7, ctx->restore7);
 }
 
-static struct ahb *l2ab_driver_probe(int argc, char *argv[]);
+static struct ahb *l2ab_driver_probe(struct connection_args *connection);
 static void l2ab_driver_destroy(struct ahb *ahb);
 static int l2ab_driver_release(struct ahb *ahb);
 static int l2ab_driver_reinit(struct ahb *ahb);
@@ -232,15 +233,10 @@ int l2ab_destroy(struct l2ab *ctx)
 }
 
 static struct ahb *
-l2ab_driver_probe(int argc, char *argv[] __unused)
+l2ab_driver_probe(struct connection_args *connection __unused)
 {
     struct l2ab *ctx;
     int rc;
-
-    // This driver doesn't require args, so if there are any we're not trying to probe it
-    if (argc > 0) {
-        return NULL;
-    }
 
     ctx = malloc(sizeof(*ctx));
     if (!ctx) {

--- a/src/bridge/p2a.c
+++ b/src/bridge/p2a.c
@@ -5,6 +5,7 @@
 #include "ahb.h"
 #include "bridge.h"
 #include "compiler.h"
+#include "connection.h"
 #include "log.h"
 #include "mb.h"
 #include "mmio.h"
@@ -208,7 +209,7 @@ static const struct ahb_ops p2ab_ahb_ops = {
     .writel = p2ab_writel,
 };
 
-static struct ahb *p2ab_driver_probe(int argc, char *argv[]);
+static struct ahb *p2ab_driver_probe(struct connection_args *connection);
 static int p2ab_driver_reinit(struct ahb *ahb);
 static void p2ab_driver_destroy(struct ahb *ahb);
 
@@ -272,15 +273,10 @@ int p2ab_destroy(struct p2ab *ctx)
 }
 
 static struct ahb *
-p2ab_driver_probe(int argc, char *argv[] __unused)
+p2ab_driver_probe(struct connection_args *connection __unused)
 {
     struct p2ab *ctx;
     int rc;
-
-    // This driver doesn't require args, so if there are any we're not trying to probe it
-    if (argc > 0) {
-        return NULL;
-    }
 
     ctx = malloc(sizeof(*ctx));
     if (!ctx) {

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -4,8 +4,14 @@
 #ifndef CULVERT_CMD_H
 #define CULVERT_CMD_H
 
-#include "ccan/autodata/autodata.h"
+#include <argp.h>
+#include <stdbool.h>
 #include <string.h>
+
+#include "connection.h"
+#include "log.h"
+
+#include "ccan/autodata/autodata.h"
 
 struct cmd {
     const char *name;
@@ -22,6 +28,54 @@ static inline int cmd_cmp(const void *a, const void *b)
     const struct cmd * const *bcmd = b;
 
     return strcmp((*acmd)->name, (*bcmd)->name);
+}
+
+/**
+ * Parse everything after the `via` word.
+ * The `via` word itself is not included in the arguments.
+ * The arguments are expected to be in the following order:
+ * 1. interface
+ * 2. ip
+ * 3. port
+ * 4. username
+ * 5. password
+ *
+ * @param argi The index of the `via` word in the argv array.
+ * @param state The argp state.
+ * @param args The connection arguments struct that should be modified.
+ */
+static inline int cmd_parse_via(int argi, struct argp_state *state,
+                                struct connection_args *args)
+{
+    logt("via parse: argi = %d, state->argc = %d\n", argi, state->argc);
+    if (argi >= state->argc) {
+        loge("Provided argi >= argp state count. This is liekly a bug!\n");
+        return -EINVAL;
+    }
+
+    /* global argc - already processed arguments - 1 (for the `via` word) */
+    int argc = state->argc - argi - 1;
+
+    /* Preflight validation if argc is either 1 or 5 */
+    if (argc != 1 && argc != 5) {
+        loge("via arguments must be either 1 or 5\n");
+        return -EINVAL;
+    }
+
+    args->interface = state->argv[argi + 1];
+
+    /* Early abort if interface is only set */
+    if (argc == 1)
+        return 0;
+
+    logt("via parse: Detected more than one argument!\n");
+    args->ip = state->argv[argi + 2];
+    args->port = strtoul(state->argv[argi + 3], NULL, 0);
+    args->username = state->argv[argi + 4];
+    args->password = state->argv[argi + 5];
+    args->internet_args = true;
+
+    return 0;
 }
 
 #endif

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -15,8 +15,8 @@
 
 struct cmd {
     const char *name;
-    const char *help;
-    int (*fn)(const char *, int, char *[]);
+    const char *description;
+    int (*fn)(int argc, char **argv);
 };
 
 AUTODATA_TYPE(cmds, struct cmd);

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -32,6 +32,32 @@ static inline int cmd_cmp(const void *a, const void *b)
 }
 
 /**
+ * Parse the memory values of a command
+ *
+ * @param state The argp state
+ * @param label The name of the value to be parsed
+ * @param out Pointer to the unsigned long in the commands' arguments struct
+ * @param arg The input value
+ */
+static inline void parse_mem_arg(struct argp_state *state, const char *label,
+                                 unsigned long *out, const char *arg)
+{
+    char *endp;
+    errno = 0;
+    *out = strtoul(arg, &endp, 0);
+    if (*out == ULONG_MAX && errno) {
+        argp_error(state, "Failed to parse %s '%s': %s", label, arg, strerror(errno));
+#if ULONG_MAX > UINT32_MAX
+    } else if (*out > UINT32_MAX) {
+        argp_error(state, "Failed to parse %s: '%s' exceeds address space", label, arg);
+#endif
+    }
+
+    if (arg == endp || *endp)
+        argp_error(state, "Invalid %s format: '%s'", label, arg);
+}
+
+/**
  * Parse everything after the `via` word.
  * The `via` word itself is not included in the arguments.
  * The arguments are expected to be in the following order:

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -4,14 +4,15 @@
 #ifndef CULVERT_CMD_H
 #define CULVERT_CMD_H
 
-#include <argp.h>
-#include <stdbool.h>
-#include <string.h>
-
+#include "host.h"
 #include "connection.h"
 #include "log.h"
 
 #include "ccan/autodata/autodata.h"
+
+#include <argp.h>
+#include <stdbool.h>
+#include <string.h>
 
 struct cmd {
     const char *name;
@@ -34,11 +35,12 @@ static inline int cmd_cmp(const void *a, const void *b)
  * Parse everything after the `via` word.
  * The `via` word itself is not included in the arguments.
  * The arguments are expected to be in the following order:
- * 1. interface
- * 2. ip
- * 3. port
- * 4. username
- * 5. password
+ * 1. bridge driver
+ * 2. interface
+ * 3. ip
+ * 4. port
+ * 5. username
+ * 6. password
  *
  * @param argi The index of the `via` word in the argv array.
  * @param state The argp state.
@@ -47,6 +49,7 @@ static inline int cmd_cmp(const void *a, const void *b)
 static inline int cmd_parse_via(int argi, struct argp_state *state,
                                 struct connection_args *args)
 {
+    int rc;
     logt("via parse: argi = %d, state->argc = %d\n", argi, state->argc);
     if (argi >= state->argc) {
         loge("Provided argi >= argp state count. This is liekly a bug!\n");
@@ -56,23 +59,39 @@ static inline int cmd_parse_via(int argi, struct argp_state *state,
     /* global argc - already processed arguments - 1 (for the `via` word) */
     int argc = state->argc - argi - 1;
 
-    /* Preflight validation if argc is either 1 or 5 */
-    if (argc != 1 && argc != 5) {
-        loge("via arguments must be either 1 or 5\n");
+    /* Preflight validation if argc is either 1, 2 or 5 */
+    if (argc != 1 && argc != 2 && argc != 6) {
+        loge("via arguments must be either 1, 2 or 5\n");
         return -EINVAL;
     }
 
-    args->interface = state->argv[argi + 1];
+    /* Resolve bridge driver to check if it even exists and bind it */
+    rc = get_bridge_driver(state->argv[argi + 1], &args->bridge_driver);
+    if (rc != 0) {
+        loge("Couldn't find provided bridge driver '%s'\n", state->argv[argi + 1]);
+        return rc;
+    }
 
-    /* Early abort if interface is only set */
-    if (argc == 1)
+    /* Early abort if driver is only set, but fail when path_required is true */
+    if (argc == 1) {
+        if (args->bridge_driver->path_required) {
+            loge("Bridge driver '%s' requires an interface path\n", args->bridge_driver->name);
+            return -EINVAL;
+        }
+        return 0;
+    }
+
+    args->interface = state->argv[argi + 2];
+
+    /* Early abort if interface is set */
+    if (argc == 2)
         return 0;
 
     logt("via parse: Detected more than one argument!\n");
-    args->ip = state->argv[argi + 2];
-    args->port = strtoul(state->argv[argi + 3], NULL, 0);
-    args->username = state->argv[argi + 4];
-    args->password = state->argv[argi + 5];
+    args->ip = state->argv[argi + 3];
+    args->port = strtoul(state->argv[argi + 4], NULL, 0);
+    args->username = state->argv[argi + 5];
+    args->password = state->argv[argi + 6];
     args->internet_args = true;
 
     return 0;

--- a/src/cmd/devmem.c
+++ b/src/cmd/devmem.c
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2018,2021 IBM Corp.
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "ahb.h"
 #include "ast.h"
@@ -10,46 +7,124 @@
 #include "cmd.h"
 #include "priv.h"
 
-static int do_devmem(const char *name, int argc, char *argv[])
+#include <argp.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static char cmd_devmem_args_doc[] = "<read ADDRESS|write ADDRESS LENGTH>";
+static char cmd_devmem_doc[] =
+    "\n"
+    "Devmem command"
+    "\v"
+    "Supported commands:\n"
+    "  read        Read data from /dev/mem\n"
+    "  write       Write data to /dev/mem\n";
+
+static struct argp_option cmd_devmem_options[] = {
+    {0},
+};
+
+struct cmd_devmem_args {
+    struct ast_ahb_args ahb_args;
+};
+
+static error_t cmd_devmem_parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct cmd_devmem_args *arguments = state->input;
+
+    switch (key) {
+    case ARGP_KEY_ARG:
+        switch (state->arg_num) {
+        case 0:
+            if (strcmp("read", arg) && strcmp("write", arg))
+                argp_error(state, "Invalid command '%s'", arg);
+
+            if (!strcmp("read", arg))
+                arguments->ahb_args.read = true;
+            break;
+        case 1:
+            arguments->ahb_args.address = strtoul(arg, NULL, 0);
+            break;
+        case 2:
+            if (!arguments->ahb_args.read) {
+                static uint32_t write_val;
+                write_val = strtoul(arg, NULL, 0);
+                arguments->ahb_args.write_value = &write_val;
+            } else
+                logd("Found third argument in read mode, ignoring...\n");
+            break;
+        }
+       break;
+   case ARGP_KEY_END:
+       if (state->arg_num < 2)
+           argp_error(state, "Not enough arguments provided. Need at least an address.");
+
+       if (!arguments->ahb_args.read && state->arg_num < 3)
+           argp_error(state, "Write mode detected but either no address or value detected");
+       break;
+   default:
+       return ARGP_ERR_UNKNOWN;
+   }
+
+    return 0;
+}
+
+static struct argp cmd_devmem_argp = {
+    .options = cmd_devmem_options,
+    .parser = cmd_devmem_parse_opt,
+    .args_doc = cmd_devmem_args_doc,
+    .doc = cmd_devmem_doc,
+};
+
+static int do_devmem(int argc, char **argv)
 {
     struct devmem _devmem, *devmem = &_devmem;
     struct ahb *ahb;
-    int cleanup;
-    int rc;
+    int cleanup, rc;
 
+    struct cmd_devmem_args arguments = {0};
+    rc = argp_parse(&cmd_devmem_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
+    if (rc != 0)
+        return rc;
+
+    /*
+     * We do not use debug_drvier_probe here as we need data
+     * that's not being returned there.
+     */
     rc = devmem_init(devmem);
     if (rc < 0) {
         bool denied = (rc == -EACCES || rc == -EPERM);
         if (denied && !priv_am_root()) {
-            priv_print_unprivileged(name);
+            priv_print_unprivileged(program_invocation_short_name);
         } else {
             errno = -rc;
             perror("devmem_init");
         }
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     ahb = devmem_as_ahb(devmem);
-    rc = ast_ahb_access(name, argc, argv, ahb);
+    rc = ast_ahb_access(&arguments.ahb_args, ahb);
     if (rc) {
         errno = -rc;
         perror("ast_ahb_access");
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     cleanup = devmem_destroy(devmem);
     if (cleanup) {
         errno = -cleanup;
         perror("devmem_destroy");
-        exit(EXIT_FAILURE);
+        return cleanup;
     }
 
     return 0;
 }
 
 static const struct cmd devmem_cmd = {
-    "devmem",
-    "<read ADDRESS|write ADDRESS VALUE>",
-    do_devmem,
+    .name = "devmem",
+    .description = "Read or write data to /dev/mem",
+    .fn = do_devmem,
 };
 REGISTER_CMD(devmem_cmd);

--- a/src/cmd/ilpc.c
+++ b/src/cmd/ilpc.c
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2018,2021 IBM Corp.
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "ahb.h"
 #include "ast.h"
@@ -9,46 +7,125 @@
 #include "cmd.h"
 #include "priv.h"
 
-static int do_ilpc(const char *name, int argc, char *argv[])
-{
-    struct ilpcb _ilpcb, *ilpcb = &_ilpcb;
-    struct ahb *ahb;
-    int cleanup;
-    int rc;
+#include <argp.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 
+static char cmd_ilpc_args_doc[] = "<read ADDRESS|write ADDRESS LENGTH>";
+static char cmd_ilpc_doc[] =
+    "\n"
+    "ilpc command"
+    "\v"
+    "Supported commands:\n"
+    "  read        Read data via iLPC\n"
+    "  write       Write data via iLPC\n";
+
+static struct argp_option cmd_ilpc_options[] = {
+    {0},
+};
+
+struct cmd_ilpc_args {
+    struct ast_ahb_args ahb_args;
+};
+
+static error_t cmd_ilpc_parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct cmd_ilpc_args *arguments = state->input;
+
+    switch (key) {
+    case ARGP_KEY_ARG:
+        switch (state->arg_num) {
+        case 0:
+            if (strcmp("read", arg) && strcmp("write", arg))
+                argp_error(state, "Invalid command '%s'", arg);
+
+            if (!strcmp("read", arg))
+                arguments->ahb_args.read = true;
+            break;
+        case 1:
+            arguments->ahb_args.address = strtoul(arg, NULL, 0);
+            break;
+        case 2:
+            if (!arguments->ahb_args.read) {
+                static uint32_t write_val;
+                write_val = strtoul(arg, NULL, 0);
+                arguments->ahb_args.write_value = &write_val;
+            } else {
+                logd("Found third argument in read mode, ignoring...\n");
+            }
+            break;
+        }
+       break;
+   case ARGP_KEY_END:
+       if (state->arg_num < 2)
+           argp_error(state, "Not enough arguments provided. Need at least an address.");
+
+       if (!arguments->ahb_args.read && state->arg_num < 3)
+           argp_error(state, "Write mode detected but either no address or value detected");
+       break;
+   default:
+       return ARGP_ERR_UNKNOWN;
+   }
+
+    return 0;
+}
+
+static struct argp cmd_ilpc_argp = {
+    .options = cmd_ilpc_options,
+    .parser = cmd_ilpc_parse_opt,
+    .args_doc = cmd_ilpc_args_doc,
+    .doc = cmd_ilpc_doc,
+};
+
+static int do_ilpc(int argc, char **argv)
+{
+    struct ilpcb _ilpcb , *ilpcb = &_ilpcb;
+    struct ahb *ahb;
+    int cleanup, rc;
+
+    struct cmd_ilpc_args arguments = {0};
+    rc = argp_parse(&cmd_ilpc_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
+    if (rc != 0)
+        return rc;
+
+    /*
+     * We do not use debug_drvier_probe here as we need data
+     * that's not being returned there.
+     */
     rc = ilpcb_init(ilpcb);
     if (rc < 0) {
         bool denied = (rc == -EACCES || rc == -EPERM);
         if (denied && !priv_am_root()) {
-            priv_print_unprivileged(name);
+            priv_print_unprivileged(program_invocation_short_name);
         } else {
             errno = -rc;
             perror("ilpcb_init");
         }
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     ahb = ilpcb_as_ahb(ilpcb);
-    rc = ast_ahb_access(name, argc, argv, ahb);
+    rc = ast_ahb_access(&arguments.ahb_args, ahb);
     if (rc) {
         errno = -rc;
         perror("ast_ahb_access");
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     cleanup = ilpcb_destroy(ilpcb);
     if (cleanup) {
         errno = -cleanup;
         perror("ilpcb_destroy");
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     return 0;
 }
 
 static const struct cmd ilpc_cmd = {
-    "ilpc",
-    "<read ADDRESS|write ADDRESS VALUE",
-    do_ilpc,
+    .name = "ilpc",
+    .description = "Read or write via iLPC",
+    .fn = do_ilpc,
 };
 REGISTER_CMD(ilpc_cmd);

--- a/src/cmd/jtag.c
+++ b/src/cmd/jtag.c
@@ -108,167 +108,167 @@ static struct argp cmd_jtag_argp = {
 
 static int run_openocd_bitbang_server(struct jtag *jtag, uint16_t port)
 {
-        int server_fd;
-        int client_fd;
-        struct sockaddr_in listen_addr;
-        struct sockaddr_in client_addr;
-        int opt = 1;
+    int server_fd;
+    int client_fd;
+    struct sockaddr_in listen_addr;
+    struct sockaddr_in client_addr;
+    int opt = 1;
 
-        if ((server_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
-                loge("socket() failed: %s\n", strerror(errno));
-                return 1;
+    if ((server_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+        loge("socket() failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt));
+
+    memset(&listen_addr, 0, sizeof(listen_addr));
+    listen_addr.sin_family = AF_INET;
+    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    listen_addr.sin_port = htons(port);
+
+    if (bind(server_fd, (struct sockaddr *)&listen_addr, sizeof(listen_addr)) < 0) {
+        loge("bind() failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (listen(server_fd, 5) < 0) {
+        loge("listen() failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    logi("Ready to accept OpenOCD remote_bitbang connection on 127.0.0.1:%u\n", port);
+
+    while (true) {
+        socklen_t addr_len = sizeof(client_addr);
+
+        if ((client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &addr_len)) < 0) {
+            loge("accept() failed: %s\n", strerror(errno));
+            return 1;
         }
 
-        setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-        setsockopt(server_fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt));
-
-        memset(&listen_addr, 0, sizeof(listen_addr));
-        listen_addr.sin_family = AF_INET;
-        listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-        listen_addr.sin_port = htons(port);
-
-        if (bind(server_fd, (struct sockaddr *)&listen_addr, sizeof(listen_addr)) < 0) {
-                loge("bind() failed: %s\n", strerror(errno));
-                return 1;
-        }
-        if (listen(server_fd, 5) < 0) {
-                loge("listen() failed: %s\n", strerror(errno));
-                return 1;
-        }
-
-        logi("Ready to accept OpenOCD remote_bitbang connection on 127.0.0.1:%u\n", port);
+        logi("New connection from %s\n", inet_ntoa(client_addr.sin_addr));
 
         while (true) {
-                socklen_t addr_len = sizeof(client_addr);
+            int rc;
+            uint8_t state;
+            uint8_t tdo;
+            uint8_t tdi;
+            uint8_t tms;
+            uint8_t tck;
 
-                if ((client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &addr_len)) < 0) {
-                        loge("accept() failed: %s\n", strerror(errno));
+            char command = 0;
+            ssize_t n = read(client_fd, &command, 1);
+            if (n <= 0) {
+                loge("Client closed connection\n");
+                close(server_fd);
+                return 1;
+            }
+
+            switch (command) {
+                /* LED blink commands */
+                case 'B':
+                case 'b':
+                    break;
+                    /* Read state */
+                case 'R':
+                    rc = jtag_bitbang_get(jtag, &tdo);
+                    if (rc < 0) {
+                        loge("jtag_bitbang_get() failed\n");
                         return 1;
-                }
+                    }
 
-                logi("New connection from %s\n", inet_ntoa(client_addr.sin_addr));
+                    // send ASCII 0 or 1 for TDO state
+                    tdo += '0';
+                    rc = write(client_fd, &tdo, 1);
+                    if (rc < 0) {
+                        loge("write(client_fd) failed: %d\n", rc);
+                        return 1;
+                    }
+                    break;
+                case 'Q':
+                    logi("Received quit request from OpenOCD\n");
+                    close(client_fd);
+                    close(server_fd);
+                    return 1;
+                    /* Data requests */
+                case '0'...'7':
+                    state = command - '0';
 
-                while (true) {
-			int rc;
-			uint8_t state;
-			uint8_t tdo;
-                        uint8_t tdi;
-                        uint8_t tms;
-                        uint8_t tck;
+                    tdi = !!(state & 1);
+                    tms = !!(state & 2);
+                    tck = !!(state & 4);
 
-                        char command = 0;
-                        ssize_t n = read(client_fd, &command, 1);
-                        if (n <= 0) {
-                                loge("Client closed connection\n");
-                                close(server_fd);
-                                return 1;
-                        }
-
-                        switch (command) {
-                        /* LED blink commands */
-                        case 'B':
-                        case 'b':
-                                break;
-                        /* Read state */
-                        case 'R':
-                                rc = jtag_bitbang_get(jtag, &tdo);
-                                if (rc < 0) {
-                                        loge("jtag_bitbang_get() failed\n");
-                                        return 1;
-                                }
-
-                                // send ASCII 0 or 1 for TDO state
-                                tdo += '0';
-                                rc = write(client_fd, &tdo, 1);
-                                if (rc < 0) {
-                                        loge("write(client_fd) failed: %d\n", rc);
-                                        return 1;
-                                }
-                                break;
-                        case 'Q':
-                                logi("Received quit request from OpenOCD\n");
-                                close(client_fd);
-                                close(server_fd);
-                                return 1;
-                        /* Data requests */
-                        case '0'...'7':
-                                state = command - '0';
-
-                                tdi = !!(state & 1);
-                                tms = !!(state & 2);
-                                tck = !!(state & 4);
-
-                                rc = jtag_bitbang_set(jtag, tck, tms, tdi);
-                                if (rc < 0) {
-                                        loge("jtag_bitbang_set() failed: %d\n", rc);
-                                        return 1;
-                                }
-                                break;
-                        /* Reset requests */
-                        case 'r':
-                        case 's':
-                        case 't':
-                        case 'u':
-                                logt("Received reset request from OpenOCD, currently unsupported\n");
-                                break;
-                        default:
-                                loge("Received unknown command from OpenOCD: %c\n", command);
-                        }
-                }
+                    rc = jtag_bitbang_set(jtag, tck, tms, tdi);
+                    if (rc < 0) {
+                        loge("jtag_bitbang_set() failed: %d\n", rc);
+                        return 1;
+                    }
+                    break;
+                    /* Reset requests */
+                case 'r':
+                case 's':
+                case 't':
+                case 'u':
+                    logt("Received reset request from OpenOCD, currently unsupported\n");
+                    break;
+                default:
+                    loge("Received unknown command from OpenOCD: %c\n", command);
+            }
         }
+    }
 }
 
 static int do_jtag(int argc, char **argv)
 {
-        struct host _host, *host = &_host;
-        struct soc _soc, *soc = &_soc;
-        struct ahb *ahb;
-        struct jtag *jtag;
-        int rc;
+    struct host _host, *host = &_host;
+    struct soc _soc, *soc = &_soc;
+    struct ahb *ahb;
+    struct jtag *jtag;
+    int rc;
 
-        struct cmd_jtag_args arguments = {0};
-        rc = argp_parse(&cmd_jtag_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
-        if (rc != 0)
-            return rc;
+    struct cmd_jtag_args arguments = {0};
+    rc = argp_parse(&cmd_jtag_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
+    if (rc != 0)
+        return rc;
 
-        if ((rc = host_init(host, &arguments.connection)) < 0) {
-                loge("Failed to initialise host interfaces: %d\n", rc);
-                rc = EXIT_FAILURE;
-                goto done;
-        }
+    if ((rc = host_init(host, &arguments.connection)) < 0) {
+        loge("Failed to initialise host interfaces: %d\n", rc);
+        rc = EXIT_FAILURE;
+        goto done;
+    }
 
-        if (!(ahb = host_get_ahb(host))) {
-                loge("Failed to acquire AHB interface, exiting\n");
-                exit(EXIT_FAILURE);
-        }
+    if (!(ahb = host_get_ahb(host))) {
+        loge("Failed to acquire AHB interface, exiting\n");
+        exit(EXIT_FAILURE);
+    }
 
-        /* Probe the SoC */
-        if ((rc = soc_probe(soc, ahb)) < 0) {
-                errno = -rc;
-                perror("soc_probe");
-                goto cleanup_host;
-        }
+    /* Probe the SoC */
+    if ((rc = soc_probe(soc, ahb)) < 0) {
+        errno = -rc;
+        perror("soc_probe");
+        goto cleanup_host;
+    }
 
-        /* Initialise the required SoC drivers */
-        if (!(jtag = jtag_get(soc, arguments.controller))) {
-                loge("Failed to acquire JTAG controller, exiting\n");
-                goto cleanup_soc;
-        }
+    /* Initialise the required SoC drivers */
+    if (!(jtag = jtag_get(soc, arguments.controller))) {
+        loge("Failed to acquire JTAG controller, exiting\n");
+        goto cleanup_soc;
+    }
 
-        jtag_route(jtag, arguments.target_bits);
+    jtag_route(jtag, arguments.target_bits);
 
-        while (true) {
-                run_openocd_bitbang_server(jtag, arguments.listen_port);
-        }
+    while (true) {
+        run_openocd_bitbang_server(jtag, arguments.listen_port);
+    }
 
 cleanup_soc:
-        soc_destroy(soc);
+    soc_destroy(soc);
 
 cleanup_host:
-        host_destroy(host);
+    host_destroy(host);
 
 done:
-        exit(rc);
+    exit(rc);
 }
 
 static const struct cmd jtag_cmd = {

--- a/src/cmd/p2a.c
+++ b/src/cmd/p2a.c
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2018,2021 IBM Corp.
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "ahb.h"
 #include "ast.h"
@@ -12,54 +8,135 @@
 #include "log.h"
 #include "priv.h"
 
-static int do_p2a(const char *name, int argc, char *argv[])
+#include <argp.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char cmd_p2a_args_doc[] = "<vga|bmc> <read ADDRESS|write ADDRESS LENGTH>";
+static char cmd_p2a_doc[] =
+    "\n"
+    "p2a command"
+    "\v"
+    "Supported PCIe devices:\n"
+    "  vga         VGA PCIe device\n"
+    "  bmc         BMC PCIe device\n"
+    "\v"
+    "Supported commands:\n"
+    "  read        Read data via p2a\n"
+    "  write       Write data via p2a\n";
+
+static struct argp_option cmd_p2a_options[] = {
+    {0},
+};
+
+struct cmd_p2a_args {
+    struct ast_ahb_args ahb_args;
+    uint16_t device_id;
+};
+
+static error_t cmd_p2a_parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct cmd_p2a_args *arguments = state->input;
+
+    switch (key) {
+    case ARGP_KEY_ARG:
+        switch (state->arg_num) {
+        case 0:
+            if (!strcmp("vga", arg))
+                arguments->device_id = AST_PCI_DID_VGA;
+            else if (!strcmp("bmc", arg))
+                arguments->device_id = AST_PCI_DID_BMC;
+            else
+                argp_error(state, "Invalid PCIe device '%s'", arg);
+            break;
+        case 1:
+            if (strcmp("read", arg) && strcmp("write", arg))
+                argp_error(state, "Invalid operation '%s'", arg);
+
+            if (!strcmp("read", arg))
+                arguments->ahb_args.read = true;
+            break;
+        case 2:
+            arguments->ahb_args.address = strtoul(arg, NULL, 0);
+            break;
+        case 3:
+            if (!arguments->ahb_args.read) {
+                static uint32_t write_val;
+                write_val = strtoul(arg, NULL, 0);
+                arguments->ahb_args.write_value = &write_val;
+            } else {
+                logd("Found third argument in read mode, ignoring...\n");
+            }
+            break;
+        }
+       break;
+   case ARGP_KEY_END:
+       if (state->arg_num < 3)
+           argp_error(state, "Not enough arguments provided. Need the device type, the operation and an address.");
+
+       if (!arguments->ahb_args.read && state->arg_num < 4)
+           argp_error(state, "Write mode detected but either no address or value detected");
+       break;
+   default:
+       return ARGP_ERR_UNKNOWN;
+   }
+
+    return 0;
+}
+
+static struct argp cmd_p2a_argp = {
+    .options = cmd_p2a_options,
+    .parser = cmd_p2a_parse_opt,
+    .args_doc = cmd_p2a_args_doc,
+    .doc = cmd_p2a_doc,
+};
+
+static int do_p2a(int argc, char **argv)
 {
     struct p2ab _p2ab, *p2ab = &_p2ab;
     struct ahb *ahb;
-    int cleanup;
-    int rc;
+    int cleanup, rc;
 
-    if (!strcmp("vga", argv[0]))
-        rc = p2ab_init(p2ab, AST_PCI_VID, AST_PCI_DID_VGA);
-    else if (!strcmp("bmc", argv[0]))
-        rc = p2ab_init(p2ab, AST_PCI_VID, AST_PCI_DID_BMC);
-    else {
-        loge("Unknown PCIe device: %s\n", argv[0]);
-        exit(EXIT_FAILURE);
-    }
+    struct cmd_p2a_args arguments = {0};
+    rc = argp_parse(&cmd_p2a_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
+    if (rc != 0)
+        return rc;
 
+    rc = p2ab_init(p2ab, AST_PCI_VID, arguments.device_id);
     if (rc < 0) {
         bool denied = (rc == -EACCES || rc == -EPERM);
         if (denied && !priv_am_root()) {
-            priv_print_unprivileged(name);
+            priv_print_unprivileged(program_invocation_short_name);
         } else {
             errno = -rc;
             perror("p2ab_init");
         }
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     ahb = p2ab_as_ahb(p2ab);
-    rc = ast_ahb_access(name, argc - 1, argv + 1, ahb);
+    rc = ast_ahb_access(&arguments.ahb_args, ahb);
     if (rc) {
         errno = -rc;
         perror("ast_ahb_access");
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     cleanup = p2ab_destroy(p2ab);
     if (cleanup) {
         errno = -cleanup;
         perror("p2ab_destroy");
-        exit(EXIT_FAILURE);
+        return cleanup;
     }
 
     return 0;
 }
 
 static const struct cmd p2a_cmd = {
-    "p2a",
-    "vga <read ADDRESS|write ADDRESS VALUE>",
-    do_p2a,
+    .name = "p2a",
+    .description = "Read or write data via p2a devices",
+    .fn = do_p2a,
 };
 REGISTER_CMD(p2a_cmd);

--- a/src/cmd/probe.c
+++ b/src/cmd/probe.c
@@ -3,88 +3,99 @@
 
 #include "cmd.h"
 #include "compiler.h"
+#include "connection.h"
 #include "host.h"
 #include "log.h"
 #include "soc.h"
 
-#include <getopt.h>
-#include <stdbool.h>
+#include <argp.h>
 #include <stdio.h>
 
-static void
-cmd_probe_help(const char *name, int argc __unused, char *argv[] __unused)
-{
-    static const char *probe_help =
-        "Usage:\n"
-        "%s probe --help\n"
-        "%s probe --interface INTERFACE ...\n"
-        "%s probe --list-interfaces\n"
-        "%s probe --require <integrity|confidentiality>\n";
+static char cmd_probe_args_doc[] = "[-l] [-r REQUIREMENT] [via DRIVER [INTERFACE [IP PORT USERNAME PASSWORD]]]";
+static char cmd_probe_doc[] =
+    "\n"
+    "Probe command"
+    "\v"
+    "Supported requirements:\n"
+    "  integrity        Require integrity\n"
+    "  confidentiality  Require confidentiality\n";
 
-    printf(probe_help, name, name, name, name);
+static struct argp_option cmd_probe_options[] = {
+    {"list-interfaces", 'l', 0, 0, "List available interfaces", 0},
+    {"require", 'r', "REQUIREMENT", 0, "Requirement to probe for", 0},
+    {0},
+};
+
+struct cmd_probe_args {
+    int list_ifaces;
+    enum bridge_mode requirement;
+    struct connection_args connection;
+};
+
+static error_t cmd_probe_parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct cmd_probe_args *arguments = state->input;
+    int rc = 0;
+
+    switch (key) {
+    case 'l':
+        arguments->list_ifaces = 1;
+        break;
+    case 'r':
+        if (strcmp("integrity", arg) && strcmp("confidentiality", arg))
+            argp_error(state, "Invalid requirement '%s'", arg);
+
+        if (!strcmp("integrity", arg))
+            arguments->requirement = bm_restricted;
+        else
+            arguments->requirement = bm_disabled;
+        break;
+    case ARGP_KEY_ARG:
+        if (!strcmp(arg, "via")) {
+            rc = cmd_parse_via(state->next - 1, state, &arguments->connection);
+            if (rc != 0)
+                argp_error(state, "Failed to parse connection arguments. Returned code %d", rc);
+            return 0;
+        }
+
+        break;
+    case ARGP_KEY_END:
+        if (!arguments->requirement)
+            arguments->requirement = bm_permissive;
+
+        if (!arguments->connection.interface)
+            arguments->connection.interface = NULL;
+        break;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
 }
 
-static int do_probe(const char *name, int argc, char *argv[])
+static struct argp cmd_probe_argp = {
+    .options = cmd_probe_options,
+    .parser = cmd_probe_parse_opt,
+    .args_doc = cmd_probe_args_doc,
+    .doc = cmd_probe_doc,
+};
+
+static int do_probe(int argc, char **argv)
 {
-    enum bridge_mode required = bm_permissive;
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
     enum bridge_mode discovered;
-    bool opt_list_ifaces = false;
-    char *opt_iface = NULL;
     struct ahb *ahb;
     int rc;
 
-    while (1) {
-        int option_index = 0;
-        int c;
-
-        static struct option long_options[] = {
-            { "help", no_argument, NULL, 'h' },
-            { "interface", required_argument, NULL, 'i' },
-            { "list-interfaces", no_argument, NULL, 'l' },
-            { "require", required_argument, NULL, 'r' },
-            { },
-        };
-
-        c = getopt_long(argc, argv, "hi:lr:", long_options, &option_index);
-        if (c == -1)
-            break;
-
-        switch (c) {
-            case 'h':
-                cmd_probe_help(name, argc, argv);
-                rc = EXIT_SUCCESS;
-                goto done;
-            case 'i':
-                opt_iface = optarg;
-                break;
-            case 'l':
-                opt_list_ifaces = true;
-                break;
-            case 'r':
-            {
-                if (!strcmp("confidentiality", optarg)) {
-                    required = bm_disabled;
-                } else if (!strcmp("integrity", optarg)) {
-                    required = bm_restricted;
-                } else {
-                    loge("Unrecognised requirement: %s\n", optarg);
-                    loge("Valid requirements:\n"
-                         "integrity\n"
-                         "confidentiality\n");
-                    rc = EXIT_FAILURE;
-                    goto done;
-                }
-                break;
-            }
-            case '?':
-                rc = EXIT_FAILURE;
-                goto done;
-        }
+    struct cmd_probe_args arguments = {0};
+    rc = argp_parse(&cmd_probe_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
+    if (rc != 0) {
+        rc = EXIT_FAILURE;
+        goto done;
     }
 
-    if ((rc = host_init(host, argc - optind, &argv[optind])) < 0) {
+    if ((rc = host_init(host, &arguments.connection) < 0)) {
         loge("Failed to initialise host interfaces: %d\n", rc);
         rc = EXIT_FAILURE;
         goto done;
@@ -101,17 +112,17 @@ static int do_probe(const char *name, int argc, char *argv[])
         goto cleanup_host;
     }
 
-    if (opt_list_ifaces) {
+    if (arguments.list_ifaces) {
         soc_list_bridge_controllers(soc);
         rc = EXIT_SUCCESS;
     } else {
-        if ((rc = soc_probe_bridge_controllers(soc, &discovered, opt_iface)) < 0) {
+        if ((rc = soc_probe_bridge_controllers(soc, &discovered, arguments.connection.interface)) < 0) {
             loge("Failed to probe SoC bridge controllers: %d\n", rc);
             rc = EXIT_FAILURE;
             goto cleanup_soc;
         }
 
-        rc = (required <= discovered) ? EXIT_SUCCESS : EXIT_FAILURE;
+        rc = (arguments.requirement <= discovered) ? EXIT_SUCCESS : EXIT_FAILURE;
     }
 
 cleanup_soc:
@@ -125,8 +136,8 @@ done:
 }
 
 static const struct cmd probe_cmd = {
-    "probe",
-    "[INTERFACE [IP PORT USERNAME PASSWORD]]",
-    do_probe,
+    .name = "probe",
+    .description = "Probe for any BMC",
+    .fn = do_probe,
 };
 REGISTER_CMD(probe_cmd);

--- a/src/cmd/read.c
+++ b/src/cmd/read.c
@@ -5,6 +5,7 @@
 #include "ast.h"
 #include "cmd.h"
 #include "compiler.h"
+#include "connection.h"
 #include "flash.h"
 #include "host.h"
 #include "log.h"
@@ -13,6 +14,7 @@
 #include "soc/sdmc.h"
 #include "soc/sfc.h"
 
+#include <argp.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -20,7 +22,93 @@
 #include <string.h>
 #include <unistd.h>
 
-static int cmd_read_firmware(int argc, char *argv[])
+static char cmd_read_args_doc[] =
+    "--type=<firmware|ram> [<ADDRESS> <LENGTH>] "
+    "[via DRIVER [INTERFACE [IP PORT USERNAME PASSWORD]]]";
+
+static char cmd_read_doc[] =
+    "\n"
+    "Read command"
+    "\v"
+    "NOTE: Only the 'ram' type can parse address and length!\n\n"
+    "All data will be written to stdout.\n\n"
+    "Supported types:\n"
+    "  firmware    Read the content from the FMC\n"
+    "  ram         Read the content from the memory\n";
+
+enum cmd_read_mode {
+    none,
+    firmware,
+    ram,
+};
+
+static struct argp_option cmd_read_options[] = {
+    { "type", 't', "TYPE", 0, "Type to be read from", 0 },
+    {0},
+};
+
+struct cmd_read_args {
+    unsigned long mem_base;
+    unsigned long mem_size;
+    struct connection_args connection;
+    enum cmd_read_mode mode;
+};
+
+static error_t cmd_read_parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct cmd_read_args *arguments = state->input;
+    int rc;
+
+    switch (key) {
+    case 't':
+        if (strcmp(arg, "firmware") && strcmp(arg, "ram"))
+            argp_error(state, "Invalid type '%s'", arg);
+
+        if (!strcmp(arg, "firmware"))
+            arguments->mode = firmware;
+        else
+            arguments->mode = ram;
+        break;
+    case ARGP_KEY_ARG:
+        if (!strcmp(arg, "via")) {
+            rc = cmd_parse_via(state->next - 1, state, &arguments->connection);
+            if (rc != 0)
+                argp_error(state, "Failed to parse connection arguments. Returned code %d", rc);
+            break;
+        }
+
+        /* If mode is not ram, skip any further args */
+        if (arguments->mode != ram)
+            break;
+
+        if (state->arg_num == 0)
+            parse_mem_arg(state, "read RAM base", &arguments->mem_base, arg);
+        else if (state->arg_num == 1)
+            parse_mem_arg(state, "read RAM size", &arguments->mem_size, arg);
+
+        break;
+    case ARGP_KEY_END:
+        if (arguments->mode == none)
+            argp_error(state, "No type to be read from defined...");
+        /* It is possible to not pass the ram base and size */
+        if (arguments->mode == ram && (state->arg_num > 0 && state->arg_num < 2))
+            argp_error(state, "Not enough arguments for ram mode...");
+        break;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+static struct argp cmd_read_argp = {
+    .options = cmd_read_options,
+    .parser = cmd_read_parse_opt,
+    .args_doc = cmd_read_args_doc,
+    .doc = cmd_read_doc,
+};
+
+static int cmd_read_firmware(struct cmd_read_args *arguments)
 {
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
@@ -32,7 +120,7 @@ static int cmd_read_firmware(int argc, char *argv[])
     int cleanup;
     int rc;
 
-    if ((rc = host_init(host, argc, argv)) < 0) {
+    if ((rc = host_init(host, &arguments->connection)) < 0) {
         loge("Failed to initialise host interfaces: %d\n", rc);
         return rc;
     }
@@ -86,56 +174,19 @@ cleanup_host:
     return rc;
 }
 
-static int cmd_read_ram(int argc, char *argv[])
+static int cmd_read_ram(struct cmd_read_args *arguments)
 {
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
     struct soc_region dram, vram;
-    unsigned long start, length;
     struct sdmc *sdmc;
     struct ahb *ahb;
-    char *endp;
     int rc;
 
-    /* FIXME: doesn't handle bridge argument parsing */
-    if (argc >= 2) {
-        errno = 0;
-        start = strtoul(argv[0], &endp, 0);
-        if (start == ULONG_MAX && errno) {
-            loge("Failed to parse RAM region start address '%s': %s\n", argv[0], strerror(errno));
-            return -errno;
-#if ULONG_MAX > UINT32_MAX
-        } else if (start > UINT32_MAX) {
-            loge("RAM region start address '%s' exceeds address space\n", argv[0]);
-            return -EINVAL;
-#endif
-        }
-        argc--;
-        argv++;
-
-        errno = 0;
-        length = strtoul(argv[0], &endp, 0);
-        if (length == ULONG_MAX && errno) {
-            loge("Failed to parse RAM region length '%s': %s\n", argv[0], strerror(errno));
-            return -errno;
-#if ULONG_MAX > UINT32_MAX
-        } else if (length > UINT32_MAX) {
-            loge("RAM region length '%s' exceeds address space\n", argv[0]);
-            return -EINVAL;
-#endif
-        }
-        argc--;
-        argv++;
-    } else {
-        start = 0;
-        length = 0;
-    }
-
-    if (UINT32_MAX - length < start) {
+    if (UINT32_MAX - arguments->mem_size < arguments->mem_base)
         return -EINVAL;
-    }
 
-    if ((rc = host_init(host, argc, argv)) < 0) {
+    if ((rc = host_init(host, &arguments->connection)) < 0) {
         loge("Failed to initialise host interfaces: %d\n", rc);
         return rc;
     }
@@ -159,28 +210,31 @@ static int cmd_read_ram(int argc, char *argv[])
         goto cleanup_soc;
     }
 
-    if (start && length) {
-        if (start < dram.start || (start + length) > (dram.start + dram.length)) {
+    if (arguments->mem_base && arguments->mem_size) {
+        if (arguments->mem_base < dram.start ||
+            (arguments->mem_base + arguments->mem_size) > (dram.start + dram.length)) {
+            loge("Ill-formed RAM region provided for write\n");
             rc = -EINVAL;
             goto cleanup_soc;
         }
 
         logi("Dumping %" PRId32 "MiB (%#.8" PRIx32 "-%#.8" PRIx32 ")",
-             length >> 20, start, start + length - 1);
+             arguments->mem_size >> 20, arguments->mem_base,
+             arguments->mem_base + arguments->mem_size - 1);
     } else {
         if ((rc = sdmc_get_vram(sdmc, &vram))) {
             goto cleanup_soc;
         }
 
-        start = dram.start;
-        length = dram.length - vram.length;
+        arguments->mem_base = dram.start;
+        arguments->mem_size = dram.length - vram.length;
 
         logi("%dMiB DRAM with %dMiB VRAM; dumping %dMiB (0x%x-0x%08x)\n",
              dram.length >> 20, vram.length >> 20,
              (dram.length - vram.length) >> 20, dram.start, vram.start - 1);
     }
 
-    rc = soc_siphon_out(soc, start, length, STDOUT_FILENO);
+    rc = soc_siphon_out(soc, arguments->mem_base, arguments->mem_size, STDOUT_FILENO);
     if (rc) {
         errno = -rc;
         perror("soc_siphon_in");
@@ -195,30 +249,36 @@ cleanup_host:
     return rc;
 }
 
-static int do_read(const char *name __unused, int argc, char *argv[])
+static int do_read(int argc, char **argv)
 {
     int rc;
 
-    if (argc < 1) {
-        loge("Not enough arguments for read command\n");
-        return EXIT_FAILURE;
-    }
+    struct cmd_read_args arguments = {0};
+    arguments.mode = none;
+    rc = argp_parse(&cmd_read_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
+    if (rc != 0)
+        return rc;
 
-    if (!strcmp("firmware", argv[0])) {
-        rc = cmd_read_firmware(argc - 1, argv + 1);
-    } else if (!strcmp("ram", argv[0])) {
-        rc = cmd_read_ram(argc - 1, argv + 1);
-    } else {
-        loge("Unsupported read type '%s'", argv[0]);
+    switch (arguments.mode) {
+    case firmware:
+        rc = cmd_read_firmware(&arguments);
+        break;
+    case ram:
+        rc = cmd_read_ram(&arguments);
+        break;
+    /* If it reaches none here, then the argument parse logic is broken. */
+    case none:
+        loge("read: Reached 'none' mode after argument parsing. This is a bug!\n");
         rc = -EINVAL;
+        break;
     }
 
-    return rc < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+    return rc;
 }
 
 static const struct cmd read_cmd = {
-    "read",
-    "<firmware|ram ADDRESS LENGTH> [INTERFACE [IP PORT USERNAME PASSWORD]]",
-    do_read,
+    .name = "read",
+    .description = "Read data from the FMC or RAM",
+    .fn = do_read,
 };
 REGISTER_CMD(read_cmd);

--- a/src/cmd/sfc.c
+++ b/src/cmd/sfc.c
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2018,2021 IBM Corp.
+
 #include "ahb.h"
 #include "ast.h"
 #include "cmd.h"
 #include "compiler.h"
+#include "connection.h"
 #include "flash.h"
 #include "host.h"
 #include "log.h"
 #include "priv.h"
 #include "soc/sfc.h"
 
+#include <argp.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,47 +21,113 @@
 
 #define SFC_FLASH_WIN (64 << 10)
 
+static char cmd_sfc_args_doc[] =
+    "<erase|read|write> ADDRESS LENGTH [via DRIVER [INTERFACE [IP PORT USERNAME PASSWORD]]]";
+
+static char cmd_sfc_doc[] =
+    "\n"
+    "SFC (SPI Flash Controller) command"
+    "\v"
+    "Supported sfcs':\n"
+    "  fmc     Firmware memory controller\n"
+    "\v"
+    "Supported commands:\n"
+    "  erase    Erase data on the specified address and length\n"
+    "  read     Read data from the specified address and length to stdout\n"
+    "  write    Write data on the specified address and length from stdin\n";
+
+static struct argp_option cmd_sfc_options[] = {
+    { "sfc", 's', "SFC", 0, "SFC to be used", 0 },
+    { 0 },
+};
+
 enum flash_op { flash_op_read, flash_op_write, flash_op_erase };
 
-static int do_sfc(const char *name __unused, int argc, char *argv[])
+struct cmd_sfc_args {
+    struct connection_args connection;
+    char *sfc;
+    uint32_t address;
+    uint32_t len;
+    enum flash_op operation;
+};
+
+static error_t cmd_sfc_parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct cmd_sfc_args *arguments = state->input;
+    int rc;
+
+    switch (key) {
+    case 's':
+        if (strcmp("fmc", arg))
+            argp_error(state, "Invalid SFC '%s'", arg);
+
+        arguments->sfc = arg;
+        break;
+    case ARGP_KEY_ARG:
+        if (!strcmp(arg, "via")) {
+            rc = cmd_parse_via(state->next - 1, state, &arguments->connection);
+            if (rc != 0)
+                argp_error(state, "Failed to parse connection arguments. Returned code %d", rc);
+            break;
+        }
+
+        switch (state->arg_num) {
+        case 0:
+            if (!strcmp("erase", arg))
+                arguments->operation = flash_op_erase;
+            else if (!strcmp("read", arg))
+                arguments->operation = flash_op_read;
+            else if (!strcmp("write", arg))
+                arguments->operation = flash_op_write;
+            else
+                argp_error(state, "Invalid command '%s'", arg);
+            break;
+        case 1:
+            arguments->address = strtoul(arg, NULL, 0);
+            break;
+        case 2:
+            arguments->len = strtoul(arg, NULL, 0);
+            break;
+        }
+       break;
+   case ARGP_KEY_END:
+       if (arguments->sfc == NULL)
+           argp_error(state, "No SFC defined.");
+       if (state->arg_num < 3)
+           argp_error(state, "Not enough arguments provided.");
+       break;
+   default:
+       return ARGP_ERR_UNKNOWN;
+   }
+
+    return 0;
+}
+
+static struct argp cmd_sfc_argp = {
+    .options = cmd_sfc_options,
+    .parser = cmd_sfc_parse_opt,
+    .args_doc = cmd_sfc_args_doc,
+    .doc = cmd_sfc_doc,
+};
+
+static int do_sfc(int argc, char **argv)
 {
     struct host _host, *host = &_host;
     struct soc _soc, *soc = &_soc;
     struct flash_chip *chip;
-    uint32_t offset, len;
-    enum flash_op op;
     struct sfc *sfc;
     struct ahb *ahb;
     char *buf;
     int rc;
 
-    if (argc < 4) {
-        loge("Not enough arguments for sfc command\n");
-        exit(EXIT_FAILURE);
-    }
+    struct cmd_sfc_args arguments = {0};
+    rc = argp_parse(&cmd_sfc_argp, argc, argv, ARGP_IN_ORDER, 0, &arguments);
+    if (rc != 0)
+        return rc;
 
-    if (strcmp("fmc", argv[0])) {
-        loge("Unsupported sfc type: '%s'\n", argv[0]);
-        exit(EXIT_FAILURE);
-    }
-
-    if (!strcmp("read", argv[1])) {
-        op = flash_op_read;
-    } else if (!strcmp("write", argv[1])) {
-        op = flash_op_write;
-    } else if (!strcmp("erase", argv[1])) {
-        op = flash_op_erase;
-    } else {
-        loge("Unsupported sfc operation: '%s'\n", argv[1]);
-        exit(EXIT_FAILURE);
-    }
-
-    offset = strtoul(argv[2], NULL, 0);
-    len = strtoul(argv[3], NULL, 0);
-
-    if ((rc = host_init(host, argc - 4, argv + 4)) < 0) {
+    if ((rc = host_init(host, &arguments.connection)) < 0) {
         loge("Failed to initialise host interfaces: %d\n", rc);
-        exit(EXIT_FAILURE);
+        return rc;
     }
 
     if (!(ahb = host_get_ahb(host))) {
@@ -71,8 +140,7 @@ static int do_sfc(const char *name __unused, int argc, char *argv[])
     if (rc < 0)
         goto cleanup_host;
 
-    ;
-    if (!(sfc = sfc_get_by_name(soc, "fmc"))) {
+    if (!(sfc = sfc_get_by_name(soc, arguments.sfc))) {
         loge("Failed to acquire SPI controller, exiting\n");
         goto cleanup_soc;
     }
@@ -81,45 +149,45 @@ static int do_sfc(const char *name __unused, int argc, char *argv[])
     if (rc < 0)
         goto cleanup_soc;
 
-    if (op == flash_op_read) {
+    if (arguments.operation == flash_op_read) {
         ssize_t egress;
 
-        buf = malloc(len);
+        buf = malloc(arguments.len);
         if (!buf)
             goto cleanup_flash;
 
-        rc = flash_read(chip, offset, buf, len);
-        egress = write(1, buf, len);
+        rc = flash_read(chip, arguments.address, buf, arguments.len);
+        egress = write(1, buf, arguments.len);
         if (egress == -1) {
             rc = -errno;
             perror("write");
         }
 
         free(buf);
-    } else if (op == flash_op_write) {
+    } else if (arguments.operation == flash_op_write) {
         ssize_t ingress;
 
-        len = SFC_FLASH_WIN;
-        buf = malloc(len);
+        arguments.len = SFC_FLASH_WIN;
+        buf = malloc(arguments.len);
         if (!buf)
             goto cleanup_flash;
 
-        while ((ingress = read(0, buf, len))) {
+        while ((ingress = read(0, buf, arguments.len))) {
             if (ingress < 0) {
                 rc = -errno;
                 break;
             }
 
-            rc = flash_write(chip, offset, buf, ingress, true);
+            rc = flash_write(chip, arguments.address, buf, ingress, true);
             if (rc < 0)
                 break;
 
-            offset += ingress;
+            arguments.address += ingress;
         }
 
         free(buf);
-    } else if (op == flash_op_erase) {
-        rc = flash_erase(chip, offset, len);
+    } else if (arguments.operation == flash_op_erase) {
+        rc = flash_erase(chip, arguments.address, arguments.len);
     }
 
 cleanup_flash:
@@ -135,8 +203,8 @@ cleanup_host:
 }
 
 static const struct cmd sfc_cmd = {
-    "sfc",
-    "fmc <erase|read|write> ADDRESS LENGTH [INTERFACE [IP PORT USERNAME PASSWORD]]",
-    do_sfc,
+    .name = "sfc",
+    .description = "Read, write or erase areas of a supported SFC",
+    .fn = do_sfc,
 };
 REGISTER_CMD(sfc_cmd);

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Tan Siewert
+
+#ifndef _CONNECTION_H
+#define _CONNECTION_H
+
+/**
+ * Common struct that can be used in subcommands to pass connection arguments.
+ * Commands that use this struct should use cmd_parse_via() to parse the arguments.
+ *
+ * The so-called "internet args" like IP, username, password, and so on are,
+ * as of now, only available if the remote is a Digi Portserver TS 16.
+ * When the arguments are set, the `internet_args` flag must be true. Otherwise,
+ * the bridge implementations will ignore the settings.
+ * Usually, you do not have to set this, as it will be set by cmd_parse_via().
+ * However, if you do have a command that only requires a sub-set of the values,
+ * then you may have to set it on your own.
+ */
+struct connection_args {
+    /** BMC interface path (e.g. /dev/ttyUSB0) */
+    const char *interface;
+
+    /** IP address of the console server */
+    const char *ip;
+
+    /** Username for connecting to the console server */
+    const char *username;
+
+    /** Password for connecting to the console server */
+    const char *password;
+
+    /** Port for connecting to the console server */
+    int port;
+
+    /**
+     * Internal flag that must be true if console server fields
+     * (IP, username, etc.) are set.
+     */
+    bool internet_args;
+};
+#endif

--- a/src/connection.h
+++ b/src/connection.h
@@ -4,6 +4,8 @@
 #ifndef _CONNECTION_H
 #define _CONNECTION_H
 
+#include "bridge.h"
+
 /**
  * Common struct that can be used in subcommands to pass connection arguments.
  * Commands that use this struct should use cmd_parse_via() to parse the arguments.
@@ -17,6 +19,9 @@
  * then you may have to set it on your own.
  */
 struct connection_args {
+    /** Bridge implementation to be used */
+    struct bridge_driver *bridge_driver;
+
     /** BMC interface path (e.g. /dev/ttyUSB0) */
     const char *interface;
 

--- a/src/culvert.c
+++ b/src/culvert.c
@@ -5,14 +5,6 @@
 /* For program_invocation_short_name */
 #define _GNU_SOURCE
 
-#include <argp.h>
-#include <errno.h>
-#include <getopt.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include "cmd.h"
 #include "config.h"
 #include "compiler.h"
@@ -22,6 +14,14 @@
 #include "host.h"
 
 #include "ccan/autodata/autodata.h"
+
+#include <argp.h>
+#include <errno.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 const char *argp_program_version = "culvert " CULVERT_VERSION;
 const char *argp_program_bug_address = "GitHub amboar/culvert";

--- a/src/host.c
+++ b/src/host.c
@@ -8,6 +8,7 @@
 #include "bridge/ilpc.h"
 #include "bridge/l2a.h"
 #include "bridge/p2a.h"
+#include "connection.h"
 #include "compiler.h"
 #include "host.h"
 #include "log.h"
@@ -58,7 +59,7 @@ out:
     return ret;
 }
 
-int host_init(struct host *ctx, int argc, char *argv[])
+int host_init(struct host *ctx, struct connection_args *connection)
 {
     struct bridge_driver **bridges;
     size_t n_bridges = 0;
@@ -81,7 +82,7 @@ int host_init(struct host *ctx, int argc, char *argv[])
 
         logd("Trying bridge driver %s\n", bridges[i]->name);
 
-        if ((ahb = bridges[i]->probe(argc, argv))) {
+        if ((ahb = bridges[i]->probe(connection))) {
             struct bridge *bridge;
 
             bridge = malloc(sizeof(*bridge));

--- a/src/host.c
+++ b/src/host.c
@@ -83,52 +83,68 @@ out:
     return ret;
 }
 
+static inline int host_probe_bridge(struct host *ctx,
+                                    struct bridge_driver *driver,
+                                    struct connection_args *connection)
+{
+    struct ahb *ahb;
+    struct bridge *bridge;
+
+    if (driver->disabled) {
+        logd("Skipping bridge driver %s\n", driver->name);
+        return 0;
+    }
+
+    logd("Trying bridge driver %s\n", driver->name);
+
+    ahb = driver->probe(connection);
+    if (!ahb)
+        return 0;
+
+    bridge = malloc(sizeof(*bridge));
+    if (!bridge)
+        return -ENOMEM;
+
+    bridge->driver = driver;
+    bridge->ahb = ahb;
+
+    list_add(&ctx->bridges, &bridge->entry);
+    return 0;
+}
+
 int host_init(struct host *ctx, struct connection_args *connection)
 {
     struct bridge_driver **bridges;
-    size_t n_bridges = 0;
-    size_t i;
+    size_t n_bridges;
     int rc;
 
+    /* Always init head for legacy reasons */
     list_head_init(&ctx->bridges);
 
-    bridges = autodata_get(bridge_drivers, &n_bridges);
-
-    logd("Found %zu registered bridge drivers\n", n_bridges);
-
-    for (i = 0; i < n_bridges; i++) {
-        struct ahb *ahb;
-
-        if (bridges[i]->disabled) {
-            logd("Skipping bridge driver %s\n", bridges[i]->name);
-            continue;
-        }
-
-        logd("Trying bridge driver %s\n", bridges[i]->name);
-
-        if ((ahb = bridges[i]->probe(connection))) {
-            struct bridge *bridge;
-
-            bridge = malloc(sizeof(*bridge));
-            if (!bridge) {
-                rc = -ENOMEM;
-                goto cleanup_bridges;
-            }
-
-            bridge->driver = bridges[i];
-            bridge->ahb = ahb;
-
-            list_add(&ctx->bridges, &bridge->entry);
-        }
+    /* If a bridge driver is defined, use it instead of probing all */
+    if (connection->bridge_driver != NULL) {
+        logd("Host probing found bridge driver '%s', using it\n",
+             connection->bridge_driver->name);
+        rc = host_probe_bridge(ctx, connection->bridge_driver, connection);
+        goto done;
     }
 
-    rc = 0;
+    bridges = autodata_get(bridge_drivers, &n_bridges);
+    logd("Found %zu registered bridge drivers\n", n_bridges);
+
+    for (size_t i = 0; i < n_bridges; i++) {
+        rc = host_probe_bridge(ctx, bridges[i], connection);
+        if (rc < 0)
+            goto cleanup_bridges;
+    }
 
 cleanup_bridges:
     autodata_free(bridges);
 
+done:
     return rc;
 }
+
 
 void host_destroy(struct host *ctx)
 {

--- a/src/host.c
+++ b/src/host.c
@@ -13,6 +13,8 @@
 #include "host.h"
 #include "log.h"
 
+#include "ccan/autodata/autodata.h"
+
 #include <errno.h>
 
 struct bridge {
@@ -48,6 +50,28 @@ int disable_bridge_driver(const char *drv)
     for (size_t i = 0; i < n_bridges; i++) {
         if (!strcmp(bridges[i]->name, drv)) {
             bridges[i]->disabled = true;
+            ret = 0;
+            goto out;
+        }
+    }
+
+out:
+    autodata_free(bridges);
+
+    return ret;
+}
+
+int get_bridge_driver(const char *drv, struct bridge_driver **bridge)
+{
+    struct bridge_driver **bridges;
+    size_t n_bridges = 0;
+    int ret = -ENOENT;
+
+    bridges = autodata_get(bridge_drivers, &n_bridges);
+
+    for (size_t i = 0; i < n_bridges; i++) {
+        if (!strcmp(bridges[i]->name, drv) && !bridges[i]->disabled) {
+            *bridge = bridges[i];
             ret = 0;
             goto out;
         }

--- a/src/host.h
+++ b/src/host.h
@@ -5,6 +5,7 @@
 #define _HOST_H
 
 #include "ahb.h"
+#include "connection.h"
 
 #include "ccan/list/list.h"
 
@@ -12,7 +13,7 @@ struct host {
 	struct list_head bridges;
 };
 
-int host_init(struct host *ctx, int argc, char *argv[]);
+int host_init(struct host *ctx, struct connection_args *connection);
 void host_destroy(struct host *ctx);
 
 int disable_bridge_driver(const char *drv);

--- a/src/host.h
+++ b/src/host.h
@@ -19,6 +19,25 @@ void host_destroy(struct host *ctx);
 int disable_bridge_driver(const char *drv);
 void print_bridge_drivers(void);
 
+/**
+ * get_bridge_driver - Look up and return a matching bridge driver
+ *
+ * Searches the autodata section for a bridge driver matching the given name
+ * and not marked as disabled. If found, sets the provided output pointer to
+ * the matching driver.
+ *
+ * @param drv:     Name of the bridge driver to look for (must not be NULL).
+ * @param bridge:  Output pointer that will be set to the matching bridge
+ *                 driver, if one is found. Must not be NULL.
+ *
+ * @return 0 if a matching driver is found and returned,
+ *         -ENOENT if no match was found.
+ *
+ * Note: The returned driver pointer is owned by the autodata system.
+ *       Do not free or modify it.
+ */
+int get_bridge_driver(const char *drv, struct bridge_driver **bridge);
+
 struct ahb *host_get_ahb(struct host *ctx);
 
 static inline int host_bridge_release_from_ahb(struct ahb *ahb)


### PR DESCRIPTION
Reopened because of fail in #71 / #70 

The argument handling is quite hard to make it good when using `getopt` with help and usage messages. The `argp` library is a better choice for this task.

Note: cleanup of dirty code or unwanted redundancies will be done from time to time in this PR. If you notice anything that bothers you, please add a comment directly. Thanks!

Checklist:
- [x] Migrate command base structure to argp
- [x] Refactor `host_init` and `ast_ahb_access` for standardised flags
- [x] Cleanup inconsistencies
- [x] Add proper git commit messages
- [x] Documentation