### PR TITLE
subprojects: dtc: Disable python dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,8 @@ project('culvert', 'c',
 add_global_link_arguments('-z', 'noexecstack', language: 'c')
 
 libfdt_dep = dependency('libfdt',
-			default_options: [ 'warning_level=1', ],
+			default_options: [ 'warning_level=1',
+					   'python=disabled' ],
 			fallback: [ 'dtc', 'libfdt_dep' ],
 			required: true)
 


### PR DESCRIPTION
dtc enables its Python bindings by default, which then require libpython3-dev/Python3 headers to be installed. 
culvert doesn't need dtc's python bindings, so let's disable them, so we don't need another external dependency.