### PR TITLE
editorconfig: add config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "editorconfig.editorconfig",
                 "ms-azuretools.vscode-docker",
                 "ms-python.python",
                 "ms-vscode.cmake-tools",

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,h,meson}]
+indent_style = space
+indent_size = 4
+
+[*.{c,h}]
+max_line_length = 80


### PR DESCRIPTION
Editorconfig forces the editor to use the same settings as the rest of the project.

This requires the editor to have the editorconfig plugin installed, but editors like (Neo)vim have built-in support for it.