### PR TITLE
meson: add aarch64-linux cross-compile config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ or to cross compile:
 $ meson setup build-arm --cross-file meson/arm-linux-gnueabi-gcc.ini && meson compile -C build-arm
 ```
 
+For arm64 (also known as `aarch64`) a different cross compile config is
+required:
+```
+$ meson setup build-aarch64 --cross-file meson/aarch64-linux-gnu-gcc.ini && meson compile -C build-aarch64
+```
+
 #### Dependencies (Debian)
 ```
 apt install build-essential flex swig bison meson device-tree-compiler libyaml-dev

--- a/meson/aarch64-linux-gnu-gcc.ini
+++ b/meson/aarch64-linux-gnu-gcc.ini
@@ -1,0 +1,12 @@
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[binaries]
+c = 'aarch64-linux-gnu-gcc'
+cpp = 'aarch64-linux-gnu-g++'
+ld = 'aarch64-linux-gnu-ld'
+strip = 'aarch64-linux-gnu-strip'
+exe_wrapper = [ 'qemu-aarch64', '-L', '/usr/aarch64-linux-gnu' ]


### PR DESCRIPTION
There are a few systems on the market that have an ASPEED chip, but have an aarch64 CPU (e.g. Ampere's Mt. Jefferson Reference platform) plus the AST2700 will have an aarch64 CPU.

Tested: Cross-compile culvert on an x86 machine to aarch64 and run the binary on an ALTRAD8UD-1L2T system (Ampere Altra Q80-30).