### PR TITLE
soc: pciectl: initialise context with calloc

### DIFF
--- a/src/soc/pciectl.c
+++ b/src/soc/pciectl.c
@@ -764,7 +764,7 @@ static int pciectl_driver_init(struct soc *soc, struct soc_device *dev)
     struct pciectl *ctx;
     int rc;
 
-    ctx = malloc(sizeof(*ctx));
+    ctx = calloc(1, sizeof(*ctx));
     if (!ctx) {
         return -ENOMEM;
     }


### PR DESCRIPTION
With the argp rewrite (likely when refactoring the bridges to be compatible with the common structs) the probe command fails on AST2500 under some circumstances with the following error:

```
[*] Found revision 0x4030303
[*] Selected devicetree for SoC 'aspeed,ast2500'
[*] Found 16 registered drivers
[*] ahb_readl: 0x1e6e202c: 0x00200000
debug:  Permissive
[*] ahb_readl: 0x1e6e2070: 0x7101d246
        Debug UART port: UART5
[*] Failed to find 'bridge-gate-names' node: -1
[*] Failed to resolve bridge gate for gate name '(null)': -22
[*] Failed to query bridge state for BMC XDMA: -22
[*] Failed to assess XDMA bridge status: -22
[*] Failed to read P2A bridge status: -22
[*] Failed to generate xdma report: -22
[*] Failed to find 'bridge-gate-names' node: -1
[*] Failed to resolve bridge gate for gate name '(null)': -22
[*] Failed to query bridge state for BMC MMIO: -22
[*] Failed to read P2A bridge status: -22
[*] Failed to generate p2a report: -22
[*] ahb_readl: 0x1e6e2070: 0x7101d246
[*] ahb_readl: 0x1e789100: 0x00000000
ilpc:   Permissive
[*] ahb_readl: 0x1e6e2070: 0x7101d246
        SuperIO address: 0x4e
[*] Failed to probe SoC bridge controllers: -22
```

It turns out that the `ctx->bridges` pointer in pciectl was not null, although it should have been.

Executing the command with valgrind shows some allocations that got lost:

```
$ valgrind --tool=memcheck --track-origins=yes --leak-check=full -s --show-leak-kinds=all ./build/src/culvert probe
==1785817== Memcheck, a memory error detector
==1785817== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==1785817== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==1785817== Command: ./build/src/culvert probe
==1785817==
--1785817-- WARNING: Serious error when reading debug info
--1785817-- When reading debug info from /sys/devices/pci0000:00/0000:00:01.3/0000:03:00.2/0000:20:00.0/0000:21:00.0/0000:22:00.0/resource1:
--1785817-- can't read file to inspect ELF header
debug:  Permissive
        Debug UART port: UART5
xdma:   Restricted
        BMC: Disabled
        VGA: Enabled
        XDMA on VGA: Enabled
        XDMA is constrained: Yes
p2a:    Permissive
        BMC: Disabled
        VGA: Enabled
        MMIO on VGA: Enabled
        [0x00000000 - 0x0fffffff]   Firmware: Writable
        [0x10000000 - 0x1fffffff]     SoC IO: Writable
        [0x20000000 - 0x2fffffff]  BMC Flash: Writable
        [0x30000000 - 0x3fffffff] Host Flash: Writable
        [0x40000000 - 0x5fffffff]   Reserved: Writable
        [0x60000000 - 0x7fffffff]   LPC Host: Writable
        [0x80000000 - 0xffffffff]       DRAM: Writable
ilpc:   Permissive
        SuperIO address: 0x4e
==1785817== Invalid write of size 8
==1785817==    at 0x1115F9: list_del_.lto_priv.1 (list.h:327)
==1785817==    by 0x112A9D: soc_bridge_controller_unregister (soc.c:585)
==1785817==    by 0x120C8B: debugctl_driver_destroy (debugctl.c:191)
==1785817==    by 0x111CF3: soc_unbind_drivers (soc.c:185)
==1785817==    by 0x111E56: soc_destroy (soc.c:218)
==1785817==    by 0x11BEF1: do_probe (probe.c:129)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==  Address 0x4a63c20 is 32 bytes inside a block of size 96 free'd
==1785817==    at 0x484417B: free (vg_replace_malloc.c:872)
==1785817==    by 0x124252: pciectl_driver_destroy (pciectl.c:819)
==1785817==    by 0x111CF3: soc_unbind_drivers (soc.c:185)
==1785817==    by 0x111E56: soc_destroy (soc.c:218)
==1785817==    by 0x11BEF1: do_probe (probe.c:129)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==  Block was alloc'd at
==1785817==    at 0x48465EF: calloc (vg_replace_malloc.c:1328)
==1785817==    by 0x124051: pciectl_driver_init (pciectl.c:767)
==1785817==    by 0x112742: soc_device_init_driver (soc.c:506)
==1785817==    by 0x112B01: soc_init_bridge_controllers (soc.c:598)
==1785817==    by 0x112C2C: soc_probe_bridge_controllers (soc.c:623)
==1785817==    by 0x11BEA1: do_probe (probe.c:119)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==
==1785817==
==1785817== HEAP SUMMARY:
==1785817==     in use at exit: 370 bytes in 8 blocks
==1785817==   total heap usage: 132 allocs, 124 frees, 89,771 bytes allocated
==1785817==
==1785817== 8 bytes in 1 blocks are still reachable in loss record 1 of 6
==1785817==    at 0x48465EF: calloc (vg_replace_malloc.c:1328)
==1785817==    by 0x10E1C2: main (culvert.c:167)
==1785817==
==1785817== 26 bytes in 1 blocks are still reachable in loss record 2 of 6
==1785817==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1785817==    by 0x48EC427: __vasprintf_internal (vasprintf.c:71)
==1785817==    by 0x48BFBD5: asprintf (asprintf.c:31)
==1785817==    by 0x10E1FF: main (culvert.c:174)
==1785817==
==1785817== 56 bytes in 1 blocks are indirectly lost in loss record 3 of 6
==1785817==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1785817==    by 0x1118AF: soc_device_bind_driver (soc.c:88)
==1785817==    by 0x111B9C: soc_bus_enumerate_devices (soc.c:147)
==1785817==    by 0x111C66: soc_bind_drivers (soc.c:169)
==1785817==    by 0x111E37: soc_probe (soc.c:211)
==1785817==    by 0x11BE3C: do_probe (probe.c:110)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==
==1785817== 56 bytes in 1 blocks are definitely lost in loss record 4 of 6
==1785817==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1785817==    by 0x115AA9: debug_driver_probe (debug.c:540)
==1785817==    by 0x10FC82: host_probe_bridge (host.c:100)
==1785817==    by 0x10FDD0: host_init (host.c:136)
==1785817==    by 0x11BDB4: do_probe (probe.c:98)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==
==1785817== 112 bytes in 2 blocks are definitely lost in loss record 5 of 6
==1785817==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1785817==    by 0x1118AF: soc_device_bind_driver (soc.c:88)
==1785817==    by 0x111B9C: soc_bus_enumerate_devices (soc.c:147)
==1785817==    by 0x111C66: soc_bind_drivers (soc.c:169)
==1785817==    by 0x111E37: soc_probe (soc.c:211)
==1785817==    by 0x11BE3C: do_probe (probe.c:110)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==
==1785817== 168 (112 direct, 56 indirect) bytes in 2 blocks are definitely lost in loss record 6 of 6
==1785817==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1785817==    by 0x1118AF: soc_device_bind_driver (soc.c:88)
==1785817==    by 0x111B9C: soc_bus_enumerate_devices (soc.c:147)
==1785817==    by 0x111A0A: soc_device_bind_driver (soc.c:110)
==1785817==    by 0x111B9C: soc_bus_enumerate_devices (soc.c:147)
==1785817==    by 0x111C66: soc_bind_drivers (soc.c:169)
==1785817==    by 0x111E37: soc_probe (soc.c:211)
==1785817==    by 0x11BE3C: do_probe (probe.c:110)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==
==1785817== LEAK SUMMARY:
==1785817==    definitely lost: 280 bytes in 5 blocks
==1785817==    indirectly lost: 56 bytes in 1 blocks
==1785817==      possibly lost: 0 bytes in 0 blocks
==1785817==    still reachable: 34 bytes in 2 blocks
==1785817==         suppressed: 0 bytes in 0 blocks
==1785817==
==1785817== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
==1785817==
==1785817== 1 errors in context 1 of 4:
==1785817== Invalid write of size 8
==1785817==    at 0x1115F9: list_del_.lto_priv.1 (list.h:327)
==1785817==    by 0x112A9D: soc_bridge_controller_unregister (soc.c:585)
==1785817==    by 0x120C8B: debugctl_driver_destroy (debugctl.c:191)
==1785817==    by 0x111CF3: soc_unbind_drivers (soc.c:185)
==1785817==    by 0x111E56: soc_destroy (soc.c:218)
==1785817==    by 0x11BEF1: do_probe (probe.c:129)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==  Address 0x4a63c20 is 32 bytes inside a block of size 96 free'd
==1785817==    at 0x484417B: free (vg_replace_malloc.c:872)
==1785817==    by 0x124252: pciectl_driver_destroy (pciectl.c:819)
==1785817==    by 0x111CF3: soc_unbind_drivers (soc.c:185)
==1785817==    by 0x111E56: soc_destroy (soc.c:218)
==1785817==    by 0x11BEF1: do_probe (probe.c:129)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==  Block was alloc'd at
==1785817==    at 0x48465EF: calloc (vg_replace_malloc.c:1328)
==1785817==    by 0x124051: pciectl_driver_init (pciectl.c:767)
==1785817==    by 0x112742: soc_device_init_driver (soc.c:506)
==1785817==    by 0x112B01: soc_init_bridge_controllers (soc.c:598)
==1785817==    by 0x112C2C: soc_probe_bridge_controllers (soc.c:623)
==1785817==    by 0x11BEA1: do_probe (probe.c:119)
==1785817==    by 0x10E26D: main (culvert.c:183)
==1785817==
==1785817== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```

Change the initialisation of the context to use calloc (i.e. initialise every byte with zero) to prevent this until the root cause has been fixed.

Tested: Run culvert probe and dump the firmware from an AST2500 and AST2600 system.